### PR TITLE
Fix #13: use RFC names as header fields

### DIFF
--- a/lib/packetgen/header/arp.rb
+++ b/lib/packetgen/header/arp.rb
@@ -3,33 +3,33 @@ module PacketGen
 
     # ARP header class
     # @author Sylvain Daubert
-    class ARP < Struct.new(:hw_type, :proto, :hw_len, :proto_len, :opcode,
-                          :src_mac, :src_ip, :dst_mac, :dst_ip, :body)
+    class ARP < Struct.new(:hrd, :pro, :hln, :pln, :op,
+                           :sha, :spa, :tha, :tpa, :body)
       include StructFu
       include HeaderMethods
       extend HeaderClassMethods
 
       # @param [Hash] options
-      # @option options [Integer] :hw_type network protocol type (default: 1)
-      # @option options [Integer] :proto internet protocol type (default: 0x800)
-      # @option options [Integer] :hw_len length of hardware addresses (default: 6)
-      # @option options [Integer] :proto_len length of internet addresses (default: 4)
-      # @option options [Integer] :opcode operation performing by sender (default: 1).
+      # @option options [Integer] :hrd network protocol type (default: 1)
+      # @option options [Integer] :pro internet protocol type (default: 0x800)
+      # @option options [Integer] :hln length of hardware addresses (default: 6)
+      # @option options [Integer] :pln length of internet addresses (default: 4)
+      # @option options [Integer] :op operation performing by sender (default: 1).
       #   known values are +request+ (1) and +reply+ (2)
-      # @option options [String] :src_mac sender hardware address
-      # @option options [String] :src_ip sender internet address
-      # @option options [String] :dst_mac target hardware address
-      # @option options [String] :dst_ip targetr internet address
+      # @option options [String] :sha sender hardware address
+      # @option options [String] :spa sender internet address
+      # @option options [String] :tha target hardware address
+      # @option options [String] :tpa targetr internet address
        def initialize(options={})
-        super Int16.new(options[:hw_type] || 1),
-              Int16.new(options[:proto] || 0x800),
-              Int8.new(options[:hw_len] || 6),
-              Int8.new(options[:proto_len] || 4),
-              Int16.new(options[:opcode] || 1),
-              Eth::MacAddr.new.parse(options[:src_mac]),
-              IP::Addr.new.parse(options[:src_ip]),
-              Eth::MacAddr.new.parse(options[:dst_mac]),
-              IP::Addr.new.parse(options[:dst_ip]),
+        super Int16.new(options[:hrd] || options[:htype] || 1),
+              Int16.new(options[:pro] || options[:ptype] || 0x800),
+              Int8.new(options[:hln] || options[:hlen] || 6),
+              Int8.new(options[:pln] || options[:plen] || 4),
+              Int16.new(options[:op] || options[:opcode] || 1),
+              Eth::MacAddr.new.parse(options[:sha] || options[:src_mac]),
+              IP::Addr.new.parse(options[:spa] || options[:src_ip]),
+              Eth::MacAddr.new.parse(options[:tha] || options[:dst_mac]),
+              IP::Addr.new.parse(options[:tpa] || options[:dst_ip]),
               StructFu::String.new.read(options[:body])
       end
 
@@ -39,107 +39,125 @@ module PacketGen
       def read(str)
         force_binary str
         raise ParseError, 'string too short for ARP' if str.size < self.sz
-        self[:hw_type].read str[0, 2]
-        self[:proto].read str[2, 2]
-        self[:hw_len].read str[4, 1]
-        self[:proto_len].read str[5, 1]
-        self[:opcode].read str[6, 2]
-        self[:src_mac].read str[8, 6]
-        self[:src_ip].read str[14, 4]
-        self[:dst_mac].read str[18, 6]
-        self[:dst_ip].read str[24, 4]
+        self[:hrd].read str[0, 2]
+        self[:pro].read str[2, 2]
+        self[:hln].read str[4, 1]
+        self[:pln].read str[5, 1]
+        self[:op].read str[6, 2]
+        self[:sha].read str[8, 6]
+        self[:spa].read str[14, 4]
+        self[:tha].read str[18, 6]
+        self[:tpa].read str[24, 4]
         self[:body].read str[28..-1]
       end
 
-      # @!attribute [rw] hw_type
+      # @!attribute [rw] hrd
       # @return [Integer]
-      def hw_type
-        self[:hw_type].to_i
+      def hrd
+        self[:hrd].to_i
       end
+      alias :htype :hrd
       
-      def hw_type=(i)
-        self[:hw_type].read i
+      def hrd=(i)
+        self[:hrd].read i
       end
+      alias :htype= :hrd=
 
-      # @!attribute [rw] proto
+      # @!attribute [rw] pro
       # @return [Integer]
-      def proto
-        self[:proto].to_i
+      def pro
+        self[:pro].to_i
       end
+      alias :ptype :pro
       
-      def proto=(i)
-        self[:proto].read i
+      def pro=(i)
+        self[:pro].read i
       end
+      alias :ptype= :pro=
 
-      # @!attribute [rw] hw_len
+      # @!attribute [rw] hln
       # @return [Integer]
-      def hw_len
-        self[:hw_len].to_i
+      def hln
+        self[:hln].to_i
       end
+      alias :hlen :hln
       
-      def hw_len=(i)
-        self[:hw_len].read i
+      def hln=(i)
+        self[:hln].read i
       end
+      alias :hlen= :hln=
 
-      # @!attribute [rw] proto_len
+      # @!attribute [rw] pln
       # @return [Integer]
-      def proto_len
-        self[:proto_len].to_i
+      def pln
+        self[:pln].to_i
       end
+      alias :plen :pln
       
-      def proto_len=(i)
-        self[:proto_len].read i
+      def pln=(i)
+        self[:pln].read i
       end
+      alias :plen= :pln=
 
-      # @!attribute [rw] opcode
+      # @!attribute [rw] op
       # @return [Integer]
-      def opcode
-        self[:opcode].to_i
+      def op
+        self[:op].to_i
       end
+      alias :opcode :op
       
-      def opcode=(i)
-        self[:opcode].read i
+      def op=(i)
+        self[:op].read i
       end
+      alias :opcode= :op=
 
-      # @!attribute [rw] src_mac
+      # @!attribute [rw] sha
       # @return [String]
-      def src_mac
-        self[:src_mac].to_x
+      def sha
+        self[:sha].to_x
       end
+      alias :src_mac :sha
       
-      def src_mac=(addr)
-        self[:src_mac].parse addr
+      def sha=(addr)
+        self[:sha].parse addr
       end
+      alias :src_mac= :sha=
 
-      # @!attribute [rw] src_ip
+      # @!attribute [rw] spa
       # @return [String]
-      def src_ip
-        self[:src_ip].to_x
+      def spa
+        self[:spa].to_x
       end
+      alias :src_ip :spa
       
-      def src_ip=(addr)
-        self[:src_ip].parse addr
+      def spa=(addr)
+        self[:spa].parse addr
       end
+      alias :src_ip= :spa=
 
-      # @!attribute [rw] dst_mac
+      # @!attribute [rw] tha
       # @return [String]
-      def dst_mac
-        self[:dst_mac].to_x
+      def tha
+        self[:tha].to_x
       end
+      alias :dst_mac :tha
       
-      def dst_mac=(addr)
-        self[:dst_mac].parse addr
+      def tha=(addr)
+        self[:tha].parse addr
       end
+      alias :dst_mac= :tha=
 
-      # @!attribute [rw] dst_ip
+      # @!attribute [rw] tpa
       # @return [String]
-      def dst_ip
-        self[:dst_ip].to_x
+      def tpa
+        self[:tpa].to_x
       end
+      alias :dst_ip :tpa
       
-      def dst_ip=(addr)
-        self[:dst_ip].parse addr
+      def tpa=(addr)
+        self[:tpa].parse addr
       end
+      alias :dst_ip= :tpa=
     end
 
     Eth.bind_header ARP, ethertype: 0x806

--- a/lib/packetgen/header/arp.rb
+++ b/lib/packetgen/header/arp.rb
@@ -142,7 +142,7 @@ module PacketGen
       end
     end
 
-    Eth.bind_header ARP, proto: 0x806
+    Eth.bind_header ARP, ethertype: 0x806
   end
 end
 

--- a/lib/packetgen/header/eth.rb
+++ b/lib/packetgen/header/eth.rb
@@ -3,7 +3,7 @@ module PacketGen
 
     # Ethernet header class
     # @author Sylvain Daubert
-    class Eth < Struct.new(:dst, :src, :proto, :body)
+    class Eth < Struct.new(:dst, :src, :ethertype, :body)
       include StructFu
       include HeaderMethods
       extend HeaderClassMethods
@@ -86,7 +86,7 @@ module PacketGen
       def initialize(options={})
         super MacAddr.new.parse(options[:dst] || '00:00:00:00:00:00'),
               MacAddr.new.parse(options[:src] || '00:00:00:00:00:00'),
-              Int16.new(options[:proto] || 0),
+              Int16.new(options[:ethertype] || 0),
               StructFu::String.new.read(options[:body])
       end
 
@@ -99,7 +99,7 @@ module PacketGen
         force_binary str
         self[:dst].read str[0, 6]
         self[:src].read str[6, 6]
-        self[:proto].read str[12, 2]
+        self[:ethertype].read str[12, 2]
         self[:body].read str[14..-1]
         self
       end
@@ -132,15 +132,15 @@ module PacketGen
 
       # Get protocol field
       # @return [Integer]
-      def proto
-        self[:proto].to_i
+      def ethertype
+        self[:ethertype].to_i
       end
 
       # Set protocol field
       # @param [Integer] proto
       # @return [Integer]
-      def proto=(proto)
-        self[:proto].value = proto
+      def ethertype=(type)
+        self[:ethertype].value = type
       end
 
       # send Eth packet on wire.

--- a/lib/packetgen/header/icmp.rb
+++ b/lib/packetgen/header/icmp.rb
@@ -92,6 +92,6 @@ module PacketGen
       end
     end
 
-    IP.bind_header ICMP, proto: ICMP::IP_PROTOCOL
+    IP.bind_header ICMP, protocol: ICMP::IP_PROTOCOL
   end
 end

--- a/lib/packetgen/header/ip.rb
+++ b/lib/packetgen/header/ip.rb
@@ -6,7 +6,7 @@ module PacketGen
     # IP header class
     # @author Sylvain Daubert
     class IP < Struct.new(:version, :ihl, :tos, :length, :id, :frag, :ttl,
-                          :proto,:sum, :src, :dst, :body)
+                          :protocol, :sum, :src, :dst, :body)
       include StructFu
       include HeaderMethods
       extend HeaderClassMethods
@@ -85,7 +85,7 @@ module PacketGen
       # @option options [Integer] :id
       # @option options [Integer] :frag
       # @option options [Integer] :ttl
-      # @option options [Integer] :proto
+      # @option options [Integer] :protocol
       # @option options [Integer] :sum IP header checksum
       # @option options [String] :src IP source dotted address
       # @option options [String] :dst IP destination dotted address
@@ -97,7 +97,7 @@ module PacketGen
               Int16.new(options[:id] || rand(65535)),
               Int16.new(options[:frag] || 0),
               Int8.new(options[:ttl] || 64),
-              Int8.new(options[:proto]),
+              Int8.new(options[:protocol]),
               Int16.new(options[:sum] || 0),
               Addr.new.parse(options[:src] || '127.0.0.1'),
               Addr.new.parse(options[:dst] || '127.0.0.1'),
@@ -119,7 +119,7 @@ module PacketGen
         self[:id].read str[4, 2]
         self[:frag].read str[6, 2]
         self[:ttl].read str[8, 1]
-        self[:proto].read str[9, 1]
+        self[:protocol].read str[9, 1]
         self[:sum].read str[10, 2]
         self[:src].read str[12, 4]
         self[:dst].read str[16, 4]
@@ -134,7 +134,7 @@ module PacketGen
         checksum += self.length
         checksum += self.id
         checksum += self.frag
-        checksum += (self.ttl << 8) | self.proto
+        checksum += (self.ttl << 8) | self.protocol
         checksum += (self[:src].to_i >> 16)
         checksum += (self[:src].to_i & 0xffff)
         checksum += self[:dst].to_i >> 16
@@ -215,17 +215,17 @@ module PacketGen
         self[:ttl].value = ttl
       end
 
-      # Getter for proto attribute
+      # Getter for protocol attribute
       # @return [Integer]
-      def proto
-        self[:proto].to_i
+      def protocol
+        self[:protocol].to_i
       end
 
-      # Setter for  proto attribute
-      # @param [Integer] proto
+      # Setter for  protocol attribute
+      # @param [Integer] protocol
       # @return [Integer]
-      def proto=(proto)
-        self[:proto].value = proto
+      def protocol=(protocol)
+        self[:protocol].value = protocol
       end
 
       # Getter for sum attribute
@@ -299,6 +299,6 @@ module PacketGen
     end
 
     Eth.bind_header IP, ethertype: 0x800
-    IP.bind_header IP, proto: 4
+    IP.bind_header IP, protocol: 4
   end
 end

--- a/lib/packetgen/header/ip.rb
+++ b/lib/packetgen/header/ip.rb
@@ -298,7 +298,7 @@ module PacketGen
       end
     end
 
-    Eth.bind_header IP, proto: 0x800
+    Eth.bind_header IP, ethertype: 0x800
     IP.bind_header IP, proto: 4
   end
 end

--- a/lib/packetgen/header/ipv6.rb
+++ b/lib/packetgen/header/ipv6.rb
@@ -250,6 +250,6 @@ module PacketGen
     end
 
     Eth.bind_header IPv6, ethertype: 0x86DD
-    IP.bind_header IPv6, proto: 41    # 6to4
+    IP.bind_header IPv6, protocol: 41    # 6to4
   end
 end

--- a/lib/packetgen/header/ipv6.rb
+++ b/lib/packetgen/header/ipv6.rb
@@ -249,7 +249,7 @@ module PacketGen
       end
     end
 
-    Eth.bind_header IPv6, proto: 0x86DD
+    Eth.bind_header IPv6, ethertype: 0x86DD
     IP.bind_header IPv6, proto: 41    # 6to4
   end
 end

--- a/lib/packetgen/header/udp.rb
+++ b/lib/packetgen/header/udp.rb
@@ -125,7 +125,7 @@ module PacketGen
       end
     end
 
-    IP.bind_header UDP, proto: UDP::IP_PROTOCOL
+    IP.bind_header UDP, protocol: UDP::IP_PROTOCOL
     IPv6.bind_header UDP, next: UDP::IP_PROTOCOL
   end
 end

--- a/spec/header/arp_spec.rb
+++ b/spec/header/arp_spec.rb
@@ -8,10 +8,10 @@ module PacketGen
         it 'creates a ARP header with default values' do
           arp = ARP.new
           expect(arp).to be_a(ARP)
-          expect(arp.hw_type).to eq(1)
-          expect(arp.proto).to eq(0x800)
-          expect(arp.hw_len).to eq(6)
-          expect(arp.proto_len).to eq(4)
+          expect(arp.htype).to eq(1)
+          expect(arp.ptype).to eq(0x800)
+          expect(arp.hlen).to eq(6)
+          expect(arp.plen).to eq(4)
           expect(arp.opcode).to eq(1)
           expect(arp.src_mac).to eq('00:00:00:00:00:00')
           expect(arp.dst_mac).to eq('00:00:00:00:00:00')
@@ -21,10 +21,10 @@ module PacketGen
 
         it 'accepts options' do
           options = {
-                     hw_type: 0xf000,
-                     proto: 0x1234,
-                     hw_len: 255,
-                     proto_len: 254,
+                     htype: 0xf000,
+                     ptype: 0x1234,
+                     hlen: 255,
+                     plen: 254,
                      opcode: 0x9999,
                      src_mac: '01:02:03:03:03:03',
                      dst_mac: 'ff:ff:ff:ff:ff:ff',
@@ -44,10 +44,10 @@ module PacketGen
         it 'sets header from a string' do
           str = (0...arp.sz).to_a.pack('C*') + 'arp body'
           arp.read str
-          expect(arp.hw_type).to eq(0x0001)
-          expect(arp.proto).to eq(0x0203)
-          expect(arp.hw_len).to eq(0x04)
-          expect(arp.proto_len).to eq(0x05)
+          expect(arp.htype).to eq(0x0001)
+          expect(arp.ptype).to eq(0x0203)
+          expect(arp.hlen).to eq(0x04)
+          expect(arp.plen).to eq(0x05)
           expect(arp.opcode).to eq(0x0607)
           expect(arp.src_mac).to eq('08:09:0a:0b:0c:0d')
           expect(arp.src_ip).to eq('14.15.16.17')
@@ -68,55 +68,55 @@ module PacketGen
         end
 
         it '#hw_type= accepts an integer' do
-          @arp.hw_type = 0xabcd
-          expect(@arp[:hw_type].value).to eq(0xabcd)
+          @arp.htype = 0xabcd
+          expect(@arp[:hrd].value).to eq(0xabcd)
         end
 
         it '#proto= accepts an integer' do
-          @arp.proto = 0xabcd
-          expect(@arp[:proto].value).to eq(0xabcd)
+          @arp.ptype = 0xabcd
+          expect(@arp[:pro].value).to eq(0xabcd)
         end
 
         it '#hw_len= accepts an integer' do
-          @arp.hw_len = 0xab
-          expect(@arp[:hw_len].value).to eq(0xab)
+          @arp.hlen = 0xab
+          expect(@arp[:hln].value).to eq(0xab)
         end
 
         it '#proto_len= accepts an integer' do
-          @arp.proto_len = 0xcd
-          expect(@arp[:proto_len].value).to eq(0xcd)
+          @arp.plen = 0xcd
+          expect(@arp[:pln].value).to eq(0xcd)
         end
 
         it '#opcode= accepts an integer' do
           @arp.opcode = 0xabcd
-          expect(@arp[:opcode].value).to eq(0xabcd)
+          expect(@arp[:op].value).to eq(0xabcd)
         end
 
         it '#src_mac= accepts a MAC address string' do
           @arp.src_mac = 'ff:fe:fd:fc:fb:fa'
           6.times do |i|
-            expect(@arp[:src_mac]["a#{i}".to_sym].to_i).to eq(0xff - i)
+            expect(@arp[:sha]["a#{i}".to_sym].to_i).to eq(0xff - i)
           end
         end
 
         it '#dst_mac= accepts a MAC address string' do
           @arp.dst_mac = 'ff:fe:fd:fc:fb:fa'
           6.times do |i|
-            expect(@arp[:dst_mac]["a#{i}".to_sym].to_i).to eq(0xff - i)
+            expect(@arp[:tha]["a#{i}".to_sym].to_i).to eq(0xff - i)
           end
         end
 
         it '#src_ip= accepts a IP address string' do
           @arp.src_ip = '128.129.130.131'
           4.times do |i|
-            expect(@arp[:src_ip]["a#{i+1}".to_sym].to_i).to eq(128+i)
+            expect(@arp[:spa]["a#{i+1}".to_sym].to_i).to eq(128+i)
           end
         end
 
         it '#dst_ip= accepts a IP address string' do
           @arp.dst_ip = '1.2.3.4'
           4.times do |i|
-            expect(@arp[:dst_ip]["a#{i+1}".to_sym].to_i).to eq(1+i)
+            expect(@arp[:tpa]["a#{i+1}".to_sym].to_i).to eq(1+i)
           end
         end
       end

--- a/spec/header/eth_spec.rb
+++ b/spec/header/eth_spec.rb
@@ -30,14 +30,14 @@ module PacketGen
           expect(eth).to be_a(Eth)
           expect(eth.dst).to eq('00:00:00:00:00:00')
           expect(eth.src).to eq('00:00:00:00:00:00')
-          expect(eth.proto).to eq(0)
+          expect(eth.ethertype).to eq(0)
         end
 
         it 'accepts options' do
           options = {
             dst: '00:01:02:03:04:05',
             src: '00:ff:ff:ff:ff:4c',
-            proto: 0x800,
+            ethertype: 0x800,
             body: 'this is a body'
           }
           eth = Eth.new(options)
@@ -55,7 +55,7 @@ module PacketGen
           eth.read str
           expect(eth.dst).to eq('00:01:02:03:04:05')
           expect(eth.src).to eq('06:07:08:09:0a:0b')
-          expect(eth.proto).to eq(0x0c0d)
+          expect(eth.ethertype).to eq(0x0c0d)
           expect(eth.body).to eq('body')
         end
 
@@ -85,8 +85,8 @@ module PacketGen
         end
 
         it '#proto= accepts an integer' do
-          @eth.proto = 0xabcd
-          expect(@eth[:proto].value).to eq(0xabcd)
+          @eth.ethertype = 0xabcd
+          expect(@eth[:ethertype].value).to eq(0xabcd)
         end
       end
 
@@ -107,13 +107,13 @@ module PacketGen
           expect(packet.is? 'Eth').to be(true)
           expect(packet.eth.dst).to eq('ff:ff:ff:ff:ff:ff')
           expect(packet.eth.src).to eq('ff:ff:ff:ff:ff:ff')
-          expect(packet.eth.proto).to eq(0x0800)
+          expect(packet.eth.ethertype).to eq(0x0800)
           expect(packet.ip.body).to eq(body)
         end
       end
 
       it '#to_s returns a binary string' do
-        ethx = Eth.new(dst: '00:01:02:03:04:05', proto: 0x800).to_s
+        ethx = Eth.new(dst: '00:01:02:03:04:05', ethertype: 0x800).to_s
         expected = PacketGen.force_binary("\x00\x01\x02\x03\x04\x05" \
                                           "\x00\x00\x00\x00\x00\x00\x08\x00")
         expect(ethx).to eq(expected)

--- a/spec/header/icmp_spec.rb
+++ b/spec/header/icmp_spec.rb
@@ -6,7 +6,7 @@ module PacketGen
     describe ICMP do
       describe 'bindings' do
         it 'in IP packets' do
-          expect(IP.known_headers[ICMP].to_h).to eq({ key: :proto, value: 1 })
+          expect(IP.known_headers[ICMP].to_h).to eq({ key: :protocol, value: 1 })
         end
 
         describe '#initialize' do

--- a/spec/header/ip_spec.rb
+++ b/spec/header/ip_spec.rb
@@ -28,7 +28,7 @@ module PacketGen
 
       describe 'binding' do
         it 'in Eth packets' do
-          expect(Eth.known_headers[IP].to_h).to eq({key: :proto, value: 0x800})
+          expect(Eth.known_headers[IP].to_h).to eq({key: :ethertype, value: 0x800})
         end
         it 'in IP packets' do
           expect(IP.known_headers[IP].to_h).to eq({key: :proto, value: 4})

--- a/spec/header/ip_spec.rb
+++ b/spec/header/ip_spec.rb
@@ -31,7 +31,7 @@ module PacketGen
           expect(Eth.known_headers[IP].to_h).to eq({key: :ethertype, value: 0x800})
         end
         it 'in IP packets' do
-          expect(IP.known_headers[IP].to_h).to eq({key: :proto, value: 4})
+          expect(IP.known_headers[IP].to_h).to eq({key: :protocol, value: 4})
         end
       end
 
@@ -45,7 +45,7 @@ module PacketGen
           expect(ip.id).to be < 65536
           expect(ip.frag).to eq(0)
           expect(ip.ttl).to eq(64)
-          expect(ip.proto).to eq(0)
+          expect(ip.protocol).to eq(0)
           expect(ip.sum).to eq(0)
           expect(ip.src).to eq('127.0.0.1')
           expect(ip.dst).to eq('127.0.0.1')
@@ -61,7 +61,7 @@ module PacketGen
             id: 153,
             frag: 0x4000,
             ttl: 2,
-            proto: 250,
+            protocol: 250,
             sum: 1,
             src: '1.1.1.1',
             dst: '2.2.2.2',
@@ -86,7 +86,7 @@ module PacketGen
           expect(ip.id).to eq(0x0506)
           expect(ip.frag).to eq(0x0708)
           expect(ip.ttl).to eq(9)
-          expect(ip.proto).to eq(10)
+          expect(ip.protocol).to eq(10)
           expect(ip.sum).to eq(0x0b0c)
           expect(ip.src).to eq('13.14.15.16')
           expect(ip.dst).to eq('17.18.19.20')
@@ -101,7 +101,7 @@ module PacketGen
 
         describe '#calc_sum' do
           it 'compute IP header checksum' do
-            ip = IP.new(length: 60, id: 0x1c46, frag: 0x4000, ttl: 64, proto: 6,
+            ip = IP.new(length: 60, id: 0x1c46, frag: 0x4000, ttl: 64, protocol: 6,
                         src: '172.16.10.99', dst: '172.16.10.12')
             ip.calc_sum
             expect(ip.sum).to eq(0xb1e6)
@@ -138,9 +138,9 @@ module PacketGen
             expect(@ip[:ttl].to_i).to eq(255)
           end
 
-          it '#proto= accepts integers' do
-            @ip.proto = 255
-            expect(@ip[:proto].to_i).to eq(255)
+          it '#protocol= accepts integers' do
+            @ip.protocol = 255
+            expect(@ip[:protocol].to_i).to eq(255)
           end
 
           it '#sum= accepts integers' do
@@ -182,7 +182,7 @@ module PacketGen
             expect(packet.is? 'IP').to be(true)
             expect(packet.ip.dst).to eq('127.0.0.1')
             expect(packet.ip.src).to eq('127.0.0.1')
-            expect(packet.ip.proto).to eq(UDP::IP_PROTOCOL)
+            expect(packet.ip.protocol).to eq(UDP::IP_PROTOCOL)
             expect(packet.udp.sport).to eq(35535)
             expect(packet.udp.dport).to eq(65535)
             expect(packet.body).to eq(body)

--- a/spec/header/ipv6_spec.rb
+++ b/spec/header/ipv6_spec.rb
@@ -34,7 +34,7 @@ module PacketGen
 
       describe 'binding' do
         it 'in Eth packets' do
-          expect(Eth.known_headers[IPv6].to_h).to eq({key: :proto, value: 0x86dd})
+          expect(Eth.known_headers[IPv6].to_h).to eq({key: :ethertype, value: 0x86dd})
         end
         it 'in IP packets' do
           expect(IP.known_headers[IPv6].to_h).to eq({key: :proto, value: 41})

--- a/spec/header/ipv6_spec.rb
+++ b/spec/header/ipv6_spec.rb
@@ -37,7 +37,7 @@ module PacketGen
           expect(Eth.known_headers[IPv6].to_h).to eq({key: :ethertype, value: 0x86dd})
         end
         it 'in IP packets' do
-          expect(IP.known_headers[IPv6].to_h).to eq({key: :proto, value: 41})
+          expect(IP.known_headers[IPv6].to_h).to eq({key: :protocol, value: 41})
         end
       end
 

--- a/spec/header/udp_spec.rb
+++ b/spec/header/udp_spec.rb
@@ -7,7 +7,7 @@ module PacketGen
 
       describe 'binding' do
         it 'in IP packets' do
-          expect(IP.known_headers[UDP].to_h).to eq({key: :proto, value: 17})
+          expect(IP.known_headers[UDP].to_h).to eq({key: :protocol, value: 17})
           expect(IPv6.known_headers[UDP].to_h).to eq({key: :next, value: 17})
         end
       end

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -109,7 +109,7 @@ module PacketGen
         expect(pkt.ip.ihl).to eq(0)
         expect(pkt.ip.tos).to eq(3)
         expect(pkt.ip.id).to eq(0x74de)
-        expect(pkt.ip.proto).to eq(0x51)
+        expect(pkt.ip.protocol).to eq(0x51)
       end
     end
 
@@ -154,10 +154,10 @@ module PacketGen
       end
 
       it 'sets protocol information in previous header' do
-        expect(@pkt.ip.proto).to eq(0)
+        expect(@pkt.ip.protocol).to eq(0)
         @pkt.add 'IP'
-        expect(@pkt.ip.proto).to eq(Header::IP.known_headers[Header::IP].value)
-        expect(@pkt.ip(2).proto).to eq(0)
+        expect(@pkt.ip.protocol).to eq(Header::IP.known_headers[Header::IP].value)
+        expect(@pkt.ip(2).protocol).to eq(0)
       end
 
       it 'raises on unknown protocol' do


### PR DESCRIPTION
Fix #13: use RFC names as header fields