### PR TITLE
Add a mechanism to declare bit fields in header classes

### DIFF
--- a/lib/packetgen/header/header_class_methods.rb
+++ b/lib/packetgen/header/header_class_methods.rb
@@ -27,7 +27,74 @@ module PacketGen
       def known_headers
         @known_headers ||= {}
       end
-    end
 
+      # Define a bitfield on given attribute
+      #   class MyHeader < Struct.new(:flags)
+      #   
+      #     def initialize(options={})
+      #       super Int16.new(options[:flags])
+      #     end
+      #     
+      #     # define a bit field on :flag attribute:
+      #     # flag1, flag2 and flag3 are 1-bit fields
+      #     # type and stype are 3-bit fields. reserved is a 6-bit field
+      #     define_bit_fields_on :flags, :flag1, :flag2, :flag3, :type, 3, :stype, 3, :reserved: 6
+      #   end
+      # A bitfield of size 1 bit defines 2 methods:
+      # * +#field?+ which returns a Boolean,
+      # * +#field=+ which takes and returns a Boolean.
+      # A bitfield of more bits defines 2 methods:
+      # * +#field+ which returns an Integer,
+      # * +#field=+ which takes and returns an Integer.
+      # @param [Symbol] attr attribute name (attribute should a {StructFu::Int}
+      #   subclass)
+      # @param [Array] args list of bitfield names. Name may be followed
+      #   by bitfield size. If no size is given, 1 bit is assumed.
+      # @return [void]
+      def define_bit_fields_on(attr, *args)
+        total_size = self.new[attr].width * 8
+        idx = total_size - 1
+
+        field = args.shift
+        while field
+          next unless field.is_a? Symbol
+          size = if args.first.is_a? Integer
+                   args.shift
+                 else
+                   1
+                 end
+          shift = idx - (size - 1)
+          field_mask = (2**size - 1) << shift
+          clear_mask = (2**total_size - 1) & (~field_mask & (2**total_size - 1))
+
+          if size == 1
+            class_eval <<-EOM
+            def #{field}?
+              val = (self[:#{attr}].to_i & #{field_mask}) >> #{shift}
+              val != 0
+            end
+            def #{field}=(v)
+              val = v ? 1 : 0
+              self[:#{attr}].value = self[:#{attr}].to_i & #{clear_mask}
+              self[:#{attr}].value |= val << #{shift}
+            end
+            EOM
+          else
+            class_eval <<-EOM
+            def #{field}
+              (self[:#{attr}].to_i & #{field_mask}) >> #{shift}
+            end
+            def #{field}=(v)
+              self[:#{attr}].value = self[:#{attr}].to_i & #{clear_mask}
+              self[:#{attr}].value |= (v & #{2**size - 1}) << #{shift}
+            end
+            EOM
+          end
+
+          idx -= size
+          field = args.shift
+        end
+      end
+    end
   end
 end

--- a/lib/packetgen/header/ip.rb
+++ b/lib/packetgen/header/ip.rb
@@ -7,9 +7,58 @@ require 'socket'
 module PacketGen
   module Header
 
-    # IP header class
+    # A IP header consists of:
+    # * a first byte ({#u8} of {Int8} type) composed of:
+    #   * a 4-bit {#version} field,
+    #   * a 4-bit IP header length ({#ihl}) field,
+    # * a total length ({#length}, {Int16} type),
+    # * a ID ({#id}, +Int16+ type),
+    # * a {#frag} worg (+Int16+) composed of:
+    #   * 3 1-bit flags ({#flag_rsv}, {#flag_df} and {#flag_mf}),
+    #   * a 13-bit {#fragment_offset} field,
+    # * a Time-to-Live ({#ttl}) field (+Int8+),
+    # * a {#protocol} field (+Int8+),
+    # * a checksum ({#sum}) field (+Int16+),
+    # * a source IP address ({#src}, {Addr} type),
+    # * a destination IP ddress ({#dst}, +Addr+ type),
+    # * and a {#body} ({String} type).
+    #
+    # == Create a IP header
+    #  # standalone
+    #  ip = PacketGen::Header::IP.new
+    #  # in a packet
+    #  pkt = PacketGen.gen('IP')
+    #  # access to IP header
+    #  pkt.ip   # => PacketGen::Header::IP
+    #
+    # == IP attributes
+    #  ip.u8 = 0x45
+    #  # the same as
+    #  ip.version = 4
+    #  ip.ihl = 5
+    #
+    #  ip.length = 0x43
+    #  ip.id = 0x1234
+    #
+    #  ip.frag = 0x2031
+    #  # the same as:
+    #  ip.flag_mf = true
+    #  ip.fragment_offset = 0x31
+    #
+    #  ip.flag_rsv?  # => Boolean
+    #  ip.flag_df?   # => Boolean
+    #  ip.flag_mf?   # => Boolean
+    #
+    #  ip.ttl = 0x40
+    #  ip.protocol = 6
+    #  ip.sum = 0xffff
+    #  ip.src = '127.0.0.1'
+    #  ip.src                # => "127.0.0.1"
+    #  ip[:src]              # => PacketGen::Header::IP::Addr
+    #  ip.dst = '127.0.0.2'
+    #  ip.body.read 'this is a body'
     # @author Sylvain Daubert
-    class IP < Struct.new(:version, :ihl, :tos, :length, :id, :frag, :ttl,
+    class IP < Struct.new(:u8, :tos, :length, :id, :frag, :ttl,
                           :protocol, :sum, :src, :dst, :body)
       include StructFu
       include HeaderMethods
@@ -94,8 +143,7 @@ module PacketGen
       # @option options [String] :src IP source dotted address
       # @option options [String] :dst IP destination dotted address
       def initialize(options={})
-        super options[:version] || 4,
-              options[:ihl] || 5,
+        super Int8.new(((options[:version] || 4) << 4) | (options[:ihl] || 5)),
               Int8.new(options[:tos] || 0),
               Int16.new(options[:length] || 20),
               Int16.new(options[:id] || rand(65535)),
@@ -108,6 +156,22 @@ module PacketGen
               StructFu::String.new.read(options[:body])
       end
 
+      # @!attribute version
+      #   @return [Integer] 4-bit version attribute
+      # @!attribute ihl
+      #   @return [Integer] 4-bit IP header length attribute
+      define_bit_fields_on :u8, :version, 4, :ihl, 4
+
+      # @!attribute flag_rsv
+      #   @return [Boolean] reserved bit from flags
+      # @!attribute flag_df
+      #   @return [Boolean] Don't Fragment flag 
+      # @!attribute flag_mf
+      #   @return [Boolena] More Fragment flags
+      # @!attribute fragment_offset
+      #   @return [Integer] 13-bit fragment offset
+      define_bit_fields_on :frag, :flag_rsv, :flag_df, :flag_mf, :fragment_offset, 13
+
       # Read a IP header from a string
       # @param [String] str binary string
       # @return [self]
@@ -115,9 +179,7 @@ module PacketGen
         return self if str.nil?
         raise ParseError, 'string too short for IP' if str.size < self.sz
         force_binary str
-        vihl = str[0, 1].unpack('C').first
-        self[:version] = vihl >> 4
-        self[:ihl] = vihl & 0x0f
+        self[:u8].read str[0, 1]
         self[:tos].read str[1, 1]
         self[:length].read str[2, 2]
         self[:id].read str[4, 2]
@@ -134,7 +196,7 @@ module PacketGen
        # Compute checksum and set +sum+ field
       # @return [Integer]
       def calc_sum
-        checksum = (self.version << 12) | (self.ihl << 8) | self.tos
+        checksum = (self[:u8].to_i << 8) | self.tos
         checksum += self.length
         checksum += self.id
         checksum += self.frag
@@ -274,13 +336,6 @@ module PacketGen
         self[:dst].parse addr
       end
       alias :destination= :dst=
-
-      # Get binary string
-      # @return [String]
-      def to_s
-        first_byte = [(version << 4) | ihl].pack('C')
-        first_byte << to_a[2..-1].map { |field| field.to_s }.join
-      end
 
       # Get IP part of pseudo header sum.
       # @return [Integer]

--- a/lib/packetgen/header/ipv6.rb
+++ b/lib/packetgen/header/ipv6.rb
@@ -10,8 +10,7 @@ module PacketGen
 
     # IPv6 header class
     # @author Sylvain Daubert
-    class IPv6 < Struct.new(:version, :traffic_class, :flow_label, :length,
-                            :next, :hop, :src, :dst, :body)
+    class IPv6 < Struct.new(:u32, :length, :next, :hop, :src, :dst, :body)
       include StructFu
       include HeaderMethods
       extend HeaderClassMethods
@@ -90,7 +89,7 @@ module PacketGen
 
       # @param [Hash] options
       # @option options [Integer] :version
-      # @option options [Integer] :traffic_length
+      # @option options [Integer] :traffic_class
       # @option options [Integer] :flow_label
       # @option options [Integer] :length payload length
       # @option options [Integer] :next
@@ -99,16 +98,25 @@ module PacketGen
       # @option options [String] :dst colon-delimited destination address
       # @option options [String] :body binary string
       def initialize(options={})
-        super options[:version] || 6,
-              options[:traffic_class] || 0,
-              options[:flow_label] || 0,
+        super Int32.new(0x60000000),
               Int16.new(options[:length]),
               Int8.new(options[:next]),
               Int8.new(options[:hop] || 64),
               Addr.new.parse(options[:src] || '::1'),
               Addr.new.parse(options[:dst] || '::1'),
               StructFu::String.new.read(options[:body])
+        self.version = options[:version] if options[:version]
+        self.traffic_class = options[:traffic_class] if options[:traffic_class]
+        self.flow_label = options[:flow_label] if options[:flow_label]
       end
+
+      # @!attribute version
+      #   @return [Integer] 4-bit version attribute
+      # @!attribute traffic_class
+      #   @return [Integer] 8-bit traffic_class attribute
+      # @!attribute flow_label
+      #   @return [Integer] 20-bit flow_label attribute
+      define_bit_fields_on :u32, :version, 4, :traffic_class, 8, :flow_label, 20
 
       # Read a IP header from a string
       # @param [String] str binary string
@@ -137,13 +145,13 @@ module PacketGen
         self.length = body.sz
       end
 
-      # Getter for length attribute
-      # @return [Integer]
+      # @!attribute length
+      #   16-bit payload length attribute
+      #   @return [Integer]
       def length
         self[:length].to_i
       end
 
-      # Setter for length attribute
       # @param [Integer] i
       # @return [Integer]
       def length=(i)
@@ -205,13 +213,6 @@ module PacketGen
         self[:dst].parse addr
       end
       alias :destination= :dst=
-
-      # Get binary string
-      # @return [String]
-      def to_s
-        first32 = (version << 28) | (traffic_class << 20) | flow_label
-        [first32].pack('N') << to_a[3..-1].map { |field| field.to_s }.join
-      end
 
       # Get IPv6 part of pseudo header sum.
       # @return [Integer]

--- a/spec/header/ipv6_spec.rb
+++ b/spec/header/ipv6_spec.rb
@@ -60,7 +60,7 @@ module PacketGen
           options = {
             version: 15,
             traffic_class: 128,
-            flow_label: 0xf851ec,
+            flow_label: 0x851ec,
             length: 10_000,
             next: 250,
             hop: 129,

--- a/spec/header/tcp_spec.rb
+++ b/spec/header/tcp_spec.rb
@@ -156,6 +156,25 @@ module PacketGen
           end
         end
       end
+
+      context 'flags field' do
+        let(:tcp) { TCP.new }
+
+        it 'may be accessed through all flag_* methods' do
+          all_flags = (%i(flag_ns flag_cwr flag_ece flag_urg flag_ack flag_psh) +
+                       %i(flag_rst flas_syn flag_fin)).reverse
+          8.downto(0) do |i|
+            expect(tcp.send "#{all_flags[i]}?").to eq(false)
+            tcp.flags = 1 << i
+            expect(tcp.send "#{all_flags[i]}?").to eq(true)
+            tcp.send "#{all_flags[i]}=", false
+            expect(tcp.flags).to eq(0)
+          end
+
+          tcp.flags = 0x155
+          9.times { |i| expect(tcp.send "#{all_flags[i]}?").to be(i % 2 == 0) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add a mechanism to declare bit fields in header classes, and use it on:
* Header::IP to define version, ihl, flags and fragemnt_offset
* Header::IPv6 to define fields from first 32-bit word
* Header::TCP to define flags

This will close #15.