### PR TITLE
Improve Packet#inspect

### DIFF
--- a/lib/packetgen.rb
+++ b/lib/packetgen.rb
@@ -83,6 +83,7 @@ module PacketGen
 end
 
 require 'packetgen/structfu'
+require 'packetgen/inspect'
 require 'packetgen/packet'
 require 'packetgen/capture'
 require 'packetgen/pcapng'

--- a/lib/packetgen/header/arp.rb
+++ b/lib/packetgen/header/arp.rb
@@ -50,10 +50,10 @@ module PacketGen
               Int8.new(options[:hln] || options[:hlen] || 6),
               Int8.new(options[:pln] || options[:plen] || 4),
               Int16.new(options[:op] || options[:opcode] || 1),
-              Eth::MacAddr.new.parse(options[:sha] || options[:src_mac]),
-              IP::Addr.new.parse(options[:spa] || options[:src_ip]),
-              Eth::MacAddr.new.parse(options[:tha] || options[:dst_mac]),
-              IP::Addr.new.parse(options[:tpa] || options[:dst_ip]),
+              Eth::MacAddr.new.from_human(options[:sha] || options[:src_mac]),
+              IP::Addr.new.from_human(options[:spa] || options[:src_ip]),
+              Eth::MacAddr.new.from_human(options[:tha] || options[:dst_mac]),
+              IP::Addr.new.from_human(options[:tpa] || options[:dst_ip]),
               StructFu::String.new.read(options[:body])
       end
 
@@ -138,48 +138,48 @@ module PacketGen
       # @!attribute [rw] sha
       # @return [String]
       def sha
-        self[:sha].to_x
+        self[:sha].to_human
       end
       alias :src_mac :sha
       
       def sha=(addr)
-        self[:sha].parse addr
+        self[:sha].from_human addr
       end
       alias :src_mac= :sha=
 
       # @!attribute [rw] spa
       # @return [String]
       def spa
-        self[:spa].to_x
+        self[:spa].to_human
       end
       alias :src_ip :spa
       
       def spa=(addr)
-        self[:spa].parse addr
+        self[:spa].from_human addr
       end
       alias :src_ip= :spa=
 
       # @!attribute [rw] tha
       # @return [String]
       def tha
-        self[:tha].to_x
+        self[:tha].to_human
       end
       alias :dst_mac :tha
       
       def tha=(addr)
-        self[:tha].parse addr
+        self[:tha].from_human addr
       end
       alias :dst_mac= :tha=
 
       # @!attribute [rw] tpa
       # @return [String]
       def tpa
-        self[:tpa].to_x
+        self[:tpa].to_human
       end
       alias :dst_ip :tpa
       
       def tpa=(addr)
-        self[:tpa].parse addr
+        self[:tpa].from_human addr
       end
       alias :dst_ip= :tpa=
     end

--- a/lib/packetgen/header/eth.rb
+++ b/lib/packetgen/header/eth.rb
@@ -55,10 +55,10 @@ module PacketGen
 
         end
 
-        # Parse a string to populate +MacAddr+
+        # Read a human-readable string to populate +MacAddr+
         # @param [String] str
         # @return [self]
-        def parse(str)
+        def from_human(str)
           return self if str.nil?
           bytes = str.split(/:/)
           unless bytes.size == 6
@@ -92,7 +92,7 @@ module PacketGen
 
         # +MacAddr+ in human readable form (colon format)
         # @return [String]
-        def to_x
+        def to_human
           members.map { |m| "#{'%02x' % self[m]}" }.join(':')
         end
       end
@@ -109,8 +109,8 @@ module PacketGen
       # @option options [String] :src MAC source address
       # @option options [Integer] :ethertype
       def initialize(options={})
-        super MacAddr.new.parse(options[:dst] || '00:00:00:00:00:00'),
-              MacAddr.new.parse(options[:src] || '00:00:00:00:00:00'),
+        super MacAddr.new.from_human(options[:dst] || '00:00:00:00:00:00'),
+              MacAddr.new.from_human(options[:src] || '00:00:00:00:00:00'),
               Int16.new(options[:ethertype] || 0),
               StructFu::String.new.read(options[:body])
       end
@@ -132,27 +132,27 @@ module PacketGen
       # Get MAC destination address
       # @return [String]
       def dst
-        self[:dst].to_x
+        self[:dst].to_human
       end
 
       # Set MAC destination address
       # @param [String] addr
       # @return [String]
       def dst=(addr)
-        self[:dst].parse addr
+        self[:dst].from_human addr
       end
 
       # Get MAC source address
       # @return [String]
       def src
-        self[:src].to_x
+        self[:src].to_human
       end
 
       # Set MAC source address
       # @param [String] addr
       # @return [String]
       def src=(addr)
-        self[:src].parse addr
+        self[:src].from_human addr
       end
 
       # Get ethertype field

--- a/lib/packetgen/header/header_methods.rb
+++ b/lib/packetgen/header/header_methods.rb
@@ -51,6 +51,17 @@ module PacketGen
         raise FormatError, 'no IP or IPv6 header in packet' if iph.nil?
         iph
       end
+
+      # Common inspect method for headers
+      # @return [String]
+      def inspect
+        str = Inspect.dashed_line(self.class, 2)
+        to_h.each do |attr, value|
+          next if attr == :body
+          str << Inspect.inspect_attribute(attr, value, 2)
+        end
+        str
+      end
     end
   end
 end

--- a/lib/packetgen/header/ip.rb
+++ b/lib/packetgen/header/ip.rb
@@ -84,10 +84,10 @@ module PacketGen
 
         end
 
-        # Parse a dotted address
+        # Read a dotted address
         # @param [String] str
         # @return [self]
-        def parse(str)
+        def from_human(str)
           return self if str.nil?
           m = str.match(IPV4_ADDR_REGEX)
           if m
@@ -118,7 +118,7 @@ module PacketGen
 
         # Addr in human readable form (dotted format)
         # @return [String]
-        def to_x
+        def to_human
           members.map { |m| "#{self[m].to_i}" }.join('.')
         end
 
@@ -151,8 +151,8 @@ module PacketGen
               Int8.new(options[:ttl] || 64),
               Int8.new(options[:protocol]),
               Int16.new(options[:checksum] || 0),
-              Addr.new.parse(options[:src] || '127.0.0.1'),
-              Addr.new.parse(options[:dst] || '127.0.0.1'),
+              Addr.new.from_human(options[:src] || '127.0.0.1'),
+              Addr.new.from_human(options[:dst] || '127.0.0.1'),
               StructFu::String.new.read(options[:body])
       end
 
@@ -310,7 +310,7 @@ module PacketGen
       # Get IP source address
       # @return [String] dotted address
       def src
-        self[:src].to_x
+        self[:src].to_human
       end
       alias :source :src
 
@@ -318,14 +318,14 @@ module PacketGen
       # @param [String] addr dotted IP address
       # @return [String]
       def src=(addr)
-        self[:src].parse addr
+        self[:src].from_human addr
       end
       alias :source= :src=
 
       # Get IP destination address
       # @return [String] dotted address
       def dst
-        self[:dst].to_x
+        self[:dst].to_human
       end
       alias :destination :dst
 
@@ -333,7 +333,7 @@ module PacketGen
       # @param [String] addr dotted IP address
       # @return [String]
       def dst=(addr)
-        self[:dst].parse addr
+        self[:dst].from_human addr
       end
       alias :destination= :dst=
 

--- a/lib/packetgen/header/ip.rb
+++ b/lib/packetgen/header/ip.rb
@@ -355,6 +355,29 @@ module PacketGen
         sockaddrin = Socket.sockaddr_in(0, dst)
         sock.send to_s, 0, sockaddrin
       end
+
+      # @return [String]
+      def inspect
+        str = Inspect.dashed_line(self.class, 2)
+        shift = Inspect.shift_level(2)
+        to_h.each do |attr, value|
+          next if attr == :body
+          str << Inspect.inspect_attribute(attr, value, 2)
+          if attr == :u8
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'version', version]
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'ihl', ihl]
+          elsif attr == :frag
+            flags = flag_rsv? ? %w(RSV) : []
+            flags << 'DF' if flag_df?
+            flags << 'MF' if flag_mf?
+            flags_str = flags.empty? ? 'none' : flags.join(',')
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'flags', flags_str]
+            foff = Inspect.int_dec_hex(fragment_offset, 4)
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'frag_offset', foff]
+          end
+        end
+        str
+      end
     end
 
     Eth.bind_header IP, ethertype: 0x800

--- a/lib/packetgen/header/ipv6.rb
+++ b/lib/packetgen/header/ipv6.rb
@@ -285,6 +285,24 @@ module PacketGen
 
         sock.sendmsg body.to_s, 0, sockaddrin, hop_limit, tc, pkt_info
       end
+
+      # @return [String]
+      def inspect
+        str = Inspect.dashed_line(self.class, 2)
+        to_h.each do |attr, value|
+          next if attr == :body
+          str << Inspect.inspect_attribute(attr, value, 2)
+          if attr == :u32
+            shift = Inspect.shift_level(2)
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'version', version]
+            tclass = Inspect.int_dec_hex(traffic_class, 2)
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'tclass', tclass]
+            fl_value = Inspect.int_dec_hex(flow_label, 5)
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'flow_label', fl_value]
+          end
+        end
+        str
+      end
     end
 
     Eth.bind_header IPv6, ethertype: 0x86DD

--- a/lib/packetgen/header/ipv6.rb
+++ b/lib/packetgen/header/ipv6.rb
@@ -73,10 +73,10 @@ module PacketGen
                 Int16.new(options[:a8])
         end
 
-        # Parse a colon-delimited address
+        # Read a colon-delimited address
         # @param [String] str
         # @return [self]
-        def parse(str)
+        def from_human(str)
           return self if str.nil?
           addr = IPAddr.new(str)
           raise ArgumentError, 'string is not a IPv6 address' unless addr.ipv6?
@@ -115,7 +115,7 @@ module PacketGen
 
         # Addr6 in human readable form (colon-delimited hex string)
         # @return [String]
-        def to_x
+        def to_human
           IPAddr.new(to_a.map { |a| a.to_i.to_s(16) }.join(':')).to_s
         end
       end
@@ -135,8 +135,8 @@ module PacketGen
               Int16.new(options[:length]),
               Int8.new(options[:next]),
               Int8.new(options[:hop] || 64),
-              Addr.new.parse(options[:src] || '::1'),
-              Addr.new.parse(options[:dst] || '::1'),
+              Addr.new.from_human(options[:src] || '::1'),
+              Addr.new.from_human(options[:dst] || '::1'),
               StructFu::String.new.read(options[:body])
         self.version = options[:version] if options[:version]
         self.traffic_class = options[:traffic_class] if options[:traffic_class]
@@ -220,7 +220,7 @@ module PacketGen
       # Getter for src attribute
       # @return [String]
       def src
-        self[:src].to_x
+        self[:src].to_human
       end
       alias :source :src
 
@@ -228,14 +228,14 @@ module PacketGen
       # @param [String] addr
       # @return [Integer]
       def src=(addr)
-        self[:src].parse addr
+        self[:src].from_human addr
       end
       alias :source= :src=
 
       # Getter for dst attribute
       # @return [String]
       def dst
-        self[:dst].to_x
+        self[:dst].to_human
       end
       alias :destination :dst
 
@@ -243,7 +243,7 @@ module PacketGen
       # @param [String] addr
       # @return [Integer]
       def dst=(addr)
-        self[:dst].parse addr
+        self[:dst].from_human addr
       end
       alias :destination= :dst=
 

--- a/lib/packetgen/header/tcp.rb
+++ b/lib/packetgen/header/tcp.rb
@@ -270,6 +270,27 @@ module PacketGen
       def urg_pointer=(urg)
         self[:urg_pointer].read urg
       end
+
+      # @return [String]
+      def inspect
+        str = Inspect.dashed_line(self.class, 2)
+        shift = Inspect.shift_level(2)
+        to_h.each do |attr, value|
+          next if attr == :body
+          str << Inspect.inspect_attribute(attr, value, 2)
+          if attr == :u16
+            doff = Inspect.int_dec_hex(data_offset, 1)
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'data_offset', doff]
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'reserved', reserved]
+            flags = ''
+            %w(ns cwr ece urg ack psh rst syn fin).each do |fl|
+              flags << (send("flag_#{fl}?") ? fl[0].upcase : '.')
+            end
+            str << shift + Inspect::INSPECT_FMT_ATTR % ['', 'flags', flags]
+          end
+        end
+        str
+      end
     end
 
     IP.bind_header TCP, protocol: TCP::IP_PROTOCOL

--- a/lib/packetgen/header/tcp.rb
+++ b/lib/packetgen/header/tcp.rb
@@ -124,7 +124,7 @@ module PacketGen
       # @!attribute flag_fin
       #  @return [Boolean] 1-bit FIN flag
       define_bit_fields_on :u16, :_, 7, :flag_ns, :flag_cwr, :flag_ece, :flag_urg,
-                           :flag_ack, :flag_psh, :flag_rst, :flas_syn, :flag_fin
+                           :flag_ack, :flag_psh, :flag_rst, :flag_syn, :flag_fin
       # Read a TCP header from a string
       # @param [String] str binary string
       # @return [self]

--- a/lib/packetgen/header/tcp/option.rb
+++ b/lib/packetgen/header/tcp/option.rb
@@ -120,7 +120,7 @@ module PacketGen
 
         # Get option as a human readable string
         # @return [String]
-        def to_x
+        def to_human
           str = self.class == Option ? "unk-#{kind}" : self.class.to_s.sub(/.*::/, '')
           if length > 2 and self[:value].to_s.size > 0
             str << ":#{self[:value].to_s.inspect}"
@@ -164,7 +164,7 @@ module PacketGen
         end
 
         # @return [String]
-        def to_x
+        def to_human
           "MSS:#{value}"
         end
       end
@@ -179,7 +179,7 @@ module PacketGen
         end
 
         # @return [String]
-        def to_x
+        def to_human
           "WS:#{value}"
         end
       end
@@ -213,7 +213,7 @@ module PacketGen
         end
 
         # @return [String]
-        def to_x
+        def to_human
           "WS:#{value}"
         end
       end
@@ -228,7 +228,7 @@ module PacketGen
         end
 
         # @return [String]
-        def to_x
+        def to_human
           "WS:#{value}"
         end
       end
@@ -243,7 +243,7 @@ module PacketGen
         end
 
         # @return [String]
-        def to_x
+        def to_human
           value, echo_reply = self[:value].unpack('NN')
           "WS:#{value};#{echo_reply}"
         end

--- a/lib/packetgen/header/tcp/option.rb
+++ b/lib/packetgen/header/tcp/option.rb
@@ -245,7 +245,7 @@ module PacketGen
         # @return [String]
         def to_human
           value, echo_reply = self[:value].unpack('NN')
-          "WS:#{value};#{echo_reply}"
+          "TS:#{value};#{echo_reply}"
         end
       end
     end

--- a/lib/packetgen/header/tcp/options.rb
+++ b/lib/packetgen/header/tcp/options.rb
@@ -69,8 +69,8 @@ module PacketGen
 
         # Get a human readable string
         # @return [String]
-        def to_x
-          map(&:to_x).join(', ')
+        def to_human
+          map(&:to_human).join(', ')
         end
 
         # Get options size in bytes

--- a/lib/packetgen/inspect.rb
+++ b/lib/packetgen/inspect.rb
@@ -8,6 +8,9 @@ module PacketGen
     # Maximum number of characters on a line for INSPECT
     INSPECT_MAX_WIDTH = 70
 
+    # Format to inspect attribute
+    INSPECT_FMT_ATTR = "%7s %12s: %s"
+
     # Create a dashed line with +obj+ class writing in it
     # @param [Object] obj
     # @param [Integer] level
@@ -32,7 +35,7 @@ module PacketGen
             else
               value.to_s
             end
-      str << "%7s %12s: %s" % [value.class.to_s.sub(/.*::/, ''), attr, val]
+      str << INSPECT_FMT_ATTR % [value.class.to_s.sub(/.*::/, ''), attr, val]
       str << "\n"
     end
 

--- a/lib/packetgen/inspect.rb
+++ b/lib/packetgen/inspect.rb
@@ -9,7 +9,7 @@ module PacketGen
     INSPECT_MAX_WIDTH = 70
 
     # Format to inspect attribute
-    INSPECT_FMT_ATTR = "%7s %12s: %s"
+    INSPECT_FMT_ATTR = "%7s %12s: %s\n"
 
     # Create a dashed line with +obj+ class writing in it
     # @param [String] name
@@ -20,6 +20,17 @@ module PacketGen
       str << '-' * (INSPECT_MAX_WIDTH - str.length) << "\n"
     end
 
+    # @return [String]
+    def self.shift_level(level=1)
+      '  ' + '  ' * level
+    end
+
+    # @param [#to_i] value
+    # @param [Integer] hex_size
+    # @return [String]
+    def self.int_dec_hex(value, hexsize)
+      "%-10s (0x%0#{hexsize}x)" % [value.to_i, value.to_i]
+    end
 
     # Format an attribute for +#inspect+.
     # 3 cases are handled:
@@ -32,17 +43,15 @@ module PacketGen
     # @param [Integer] level
     # @return [String]
     def self.inspect_attribute(attr, value, level=1)
-      str = '  ' + '  ' * level
+      str = shift_level(level)
       val = if value.is_a? StructFu::Int
-              sz = value.to_s.size
-              "%-10s (0x%0#{2*sz}x)" % [value.to_i, value.to_i]
+              int_dec_hex(value, value.to_s.size * 2)
             elsif value.respond_to? :to_human
               value.to_human
             else
               value.to_s
             end
       str << INSPECT_FMT_ATTR % [value.class.to_s.sub(/.*::/, ''), attr, val]
-      str << "\n"
     end
 
     # @param [#to_s] body

--- a/lib/packetgen/inspect.rb
+++ b/lib/packetgen/inspect.rb
@@ -12,7 +12,7 @@ module PacketGen
     INSPECT_FMT_ATTR = "%7s %12s: %s"
 
     # Create a dashed line with +obj+ class writing in it
-    # @param [Object] obj
+    # @param [String] name
     # @param [Integer] level
     # @return [String]
     def self.dashed_line(name, level=1)
@@ -23,8 +23,8 @@ module PacketGen
 
     # Format an attribute for +#inspect+.
     # 3 cases are handled:
-    # * attribute value is a {Int}: show value as integer and in hexdecimal
-    #   format,
+    # * attribute value is a {StructFu::Int}: show value as integer and in
+    #   hexdecimal format,
     # * attribute value responds to +#to_human+: call it,
     # * else, +#to_s+ is used to format attribute value.
     # @param [Symbol] attr attribute name

--- a/lib/packetgen/inspect.rb
+++ b/lib/packetgen/inspect.rb
@@ -1,0 +1,58 @@
+module PacketGen
+
+  # {Inspect} module provides methods to help writing +inspect+
+  # @api private
+  # @author Sylvain Daubert
+  module Inspect
+
+    # Maximum number of characters on a line for INSPECT
+    INSPECT_MAX_WIDTH = 70
+
+    # Create a dashed line with +obj+ class writing in it
+    # @param [Object] obj
+    # @param [Integer] level
+    # @return [String]
+    def self.dashed_line(name, level=1)
+      str = '--' * level << " #{name} "
+      str << '-' * (INSPECT_MAX_WIDTH - str.length) << "\n"
+    end
+
+
+    # @param [Symbol] attr attribute name
+    # @param [Object] value attribute value
+    # @param [Integer] level
+    # @return [String]
+    def self.inspect_attribute(attr, value, level=1)
+      str = '  ' + '  ' * level
+      val = if value.is_a? StructFu::Int
+              sz = value.to_s.size
+              "%-10s (0x%0#{2*sz}x)" % [value.to_i, value.to_i]
+            elsif value.respond_to? :to_x
+              value.to_x
+            else
+              value.to_s
+            end
+      str << "%7s %12s: %s" % [value.class.to_s.sub(/.*::/, ''), attr, val]
+      str << "\n"
+    end
+
+    # @param [#to_s] body
+    # @return [String]
+    def self.inspect_body(body)
+      str = dashed_line('Body', 2)
+      str << (0..15).to_a.map { |v| " %02d" % v}.join << "\n"
+      str << '-' * INSPECT_MAX_WIDTH << "\n"
+      if body.size > 0
+        (body.size / 16 + 1).times do |i|
+          octets = body.to_s[i*16, 16].unpack('C*')
+          o_str = octets.map { |v| " %02x" % v}.join
+          str << o_str
+          str << ' ' * (3*16 - o_str.size) unless o_str.size >= 3*16
+          str << '  ' << octets.map { |v| v < 128 && v > 13 ? v.chr : '.' }.join
+          str << "\n"
+        end
+      end
+      str << '-' * INSPECT_MAX_WIDTH << "\n"
+    end
+  end
+end

--- a/lib/packetgen/inspect.rb
+++ b/lib/packetgen/inspect.rb
@@ -21,6 +21,12 @@ module PacketGen
     end
 
 
+    # Format an attribute for +#inspect+.
+    # 3 cases are handled:
+    # * attribute value is a {Int}: show value as integer and in hexdecimal
+    #   format,
+    # * attribute value responds to +#to_human+: call it,
+    # * else, +#to_s+ is used to format attribute value.
     # @param [Symbol] attr attribute name
     # @param [Object] value attribute value
     # @param [Integer] level
@@ -30,8 +36,8 @@ module PacketGen
       val = if value.is_a? StructFu::Int
               sz = value.to_s.size
               "%-10s (0x%0#{2*sz}x)" % [value.to_i, value.to_i]
-            elsif value.respond_to? :to_x
-              value.to_x
+            elsif value.respond_to? :to_human
+              value.to_human
             else
               value.to_s
             end

--- a/lib/packetgen/packet.rb
+++ b/lib/packetgen/packet.rb
@@ -46,9 +46,6 @@ module PacketGen
     # @return [Array<Header::Base]
     attr_reader :headers
 
-    # @private maximum number of characters on a line for INSPECT
-    INSPECT_MAX_WIDTH = 70
-
     # Create a new Packet
     # @param [String] protocol base protocol for packet
     # @param [Hash] options specific options for +protocol+
@@ -262,15 +259,11 @@ module PacketGen
 
     # @return [String]
     def inspect
-      str = dashed_line(self.class)
+      str = Inspect.dashed_line(self.class)
       @headers.each do |header|
-        str << dashed_line(header.class, 2)
-        header.to_h.each do |attr, value|
-          next if attr == :body
-          str << inspect_line(attr, value, 2)
-        end
+        str << header.inspect
       end
-      str << inspect_body
+      str << Inspect.inspect_body(body)
     end
 
     # @param [Packet] other
@@ -318,42 +311,6 @@ module PacketGen
       klass = Header.const_get(protocol)
       raise ArgumentError, "unknown #{protocol} protocol" unless klass.is_a? Class
       klass
-    end
-
-    def dashed_line(name, level=1)
-      str = '--' * level << " #{name} "
-      str << '-' * (INSPECT_MAX_WIDTH - str.length) << "\n"
-    end
-
-    def inspect_line(attr, value, level=1)
-      str = '  ' + '  ' * level
-      val = if value.is_a? StructFu::Int
-              sz = value.to_s.size
-              "%-10s (0x%0#{2*sz}x)" % [value.to_i, value.to_i]
-            elsif value.respond_to? :to_x
-              value.to_x
-            else
-              value.to_s
-            end
-      str << "%7s %10s: %s" % [value.class.to_s.sub(/.*::/, ''), attr, val]
-      str << "\n"
-    end
-
-    def inspect_body
-      str = dashed_line('Body', 2)
-      str << (0..15).to_a.map { |v| " %02d" % v}.join << "\n"
-      str << '-' * INSPECT_MAX_WIDTH << "\n"
-      if body.size > 0
-        (body.size / 16 + 1).times do |i|
-          octets = body.to_s[i*16, 16].unpack('C*')
-          o_str = octets.map { |v| " %02x" % v}.join
-          str << o_str
-          str << ' ' * (3*16 - o_str.size) unless o_str.size >= 3*16
-          str << '  ' << octets.map { |v| v < 128 && v > 13 ? v.chr : '.' }.join
-          str << "\n"
-        end
-      end
-      str << '-' * INSPECT_MAX_WIDTH << "\n"
     end
   end
 end

--- a/spec/header/arp_spec.rb
+++ b/spec/header/arp_spec.rb
@@ -121,14 +121,29 @@ module PacketGen
         end
       end
 
-      it '#to_s returns a binary string' do
-        arp = ARP.new(src_mac: '00:1b:11:51:b7:ce', dst_mac: '00:00:00:00:00:00',
-                      src_ip: '192.168.1.105', dst_ip: '192.168.1.2')
-        expected = "\x00\x01\x08\x00\x06\x04\x00\x01\x00\x1b\x11\x51\xb7\xce" \
-          "\xc0\xa8\x01\x69\x00\x00\x00\x00\x00\x00\xc0\xa8\x01\x02"
-        PacketGen.force_binary(expected)
-        expect(arp.to_s).to eq(expected)
+      describe '#to_s' do
+        it 'returns a binary string' do
+          arp = ARP.new(src_mac: '00:1b:11:51:b7:ce',
+                        dst_mac: '00:00:00:00:00:00',
+                        src_ip: '192.168.1.105',
+                        dst_ip: '192.168.1.2')
+          expected = "\x00\x01\x08\x00\x06\x04\x00\x01\x00\x1b\x11\x51\xb7\xce" \
+                     "\xc0\xa8\x01\x69\x00\x00\x00\x00\x00\x00\xc0\xa8\x01\x02"
+          PacketGen.force_binary(expected)
+          expect(arp.to_s).to eq(expected)
+        end
       end
-     end
+
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          arp = ARP.new
+          str = arp.inspect
+          expect(str).to be_a(String)
+          (arp.members - %i(body)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/header/eth_spec.rb
+++ b/spec/header/eth_spec.rb
@@ -112,11 +112,24 @@ module PacketGen
         end
       end
 
-      it '#to_s returns a binary string' do
-        ethx = Eth.new(dst: '00:01:02:03:04:05', ethertype: 0x800).to_s
-        expected = PacketGen.force_binary("\x00\x01\x02\x03\x04\x05" \
-                                          "\x00\x00\x00\x00\x00\x00\x08\x00")
-        expect(ethx).to eq(expected)
+      describe '#to_s' do
+        it 'returns a binary string' do
+          ethx = Eth.new(dst: '00:01:02:03:04:05', ethertype: 0x800).to_s
+          expected = PacketGen.force_binary("\x00\x01\x02\x03\x04\x05" \
+                                            "\x00\x00\x00\x00\x00\x00\x08\x00")
+          expect(ethx).to eq(expected)
+        end
+      end
+
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          eth = Eth.new
+          str = eth.inspect
+          expect(str).to be_a(String)
+          (eth.members - %i(body)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
       end
     end
   end

--- a/spec/header/eth_spec.rb
+++ b/spec/header/eth_spec.rb
@@ -5,7 +5,7 @@ module PacketGen
 
     describe Eth::MacAddr do
       before(:each) do
-        @mac = Eth::MacAddr.new.parse('00:01:02:03:04:05')
+        @mac = Eth::MacAddr.new.from_human('00:01:02:03:04:05')
       end
 
       it '#parse a MAC address string' do
@@ -17,8 +17,8 @@ module PacketGen
         expect(@mac.a5).to eq(5)
       end
 
-      it '#to_x returns a MAC address string' do
-        expect(@mac.to_x).to eq('00:01:02:03:04:05')
+      it '#to_human returns a MAC address string' do
+        expect(@mac.to_human).to eq('00:01:02:03:04:05')
       end
     end
 

--- a/spec/header/icmp_spec.rb
+++ b/spec/header/icmp_spec.rb
@@ -8,76 +8,87 @@ module PacketGen
         it 'in IP packets' do
           expect(IP.known_headers[ICMP].to_h).to eq({ key: :protocol, value: 1 })
         end
+      end
 
-        describe '#initialize' do
-          it 'creates a ICMP header with default values' do
-            icmp = ICMP.new
-            expect(icmp).to be_a(ICMP)
-            expect(icmp.type).to eq(0)
-            expect(icmp.code).to eq(0)
-            expect(icmp.checksum).to eq(0)
-            expect(icmp.body).to eq('')
-          end
-
-          it 'accepts options' do
-            icmp = ICMP.new(type: 255, code: 254, checksum: 0x1234, body: 'abcd')
-            expect(icmp.type).to eq(255)
-            expect(icmp.code).to eq(254)
-            expect(icmp.checksum).to eq(0x1234)
-            expect(icmp.body).to eq('abcd')
-          end
+      describe '#initialize' do
+        it 'creates a ICMP header with default values' do
+          icmp = ICMP.new
+          expect(icmp).to be_a(ICMP)
+          expect(icmp.type).to eq(0)
+          expect(icmp.code).to eq(0)
+          expect(icmp.checksum).to eq(0)
+          expect(icmp.body).to eq('')
         end
 
-        describe '#read' do
-          let(:icmp) { ICMP.new}
+        it 'accepts options' do
+          icmp = ICMP.new(type: 255, code: 254, checksum: 0x1234, body: 'abcd')
+          expect(icmp.type).to eq(255)
+          expect(icmp.code).to eq(254)
+          expect(icmp.checksum).to eq(0x1234)
+          expect(icmp.body).to eq('abcd')
+        end
+      end
 
-          it 'sets header from a string' do
-            str = (1..icmp.sz).to_a.pack('C*') + 'body'
-            icmp.read str
-            expect(icmp.type).to eq(1)
-            expect(icmp.code).to eq(2)
-            expect(icmp.checksum).to eq(0x0304)
-            expect(icmp.body).to eq('body')
-          end
+      describe '#read' do
+        let(:icmp) { ICMP.new}
 
-          it 'raises when str is too short' do
-            expect { icmp.read 'aa' }.to raise_error(ParseError, /too short/)
-            expect { icmp.read('aaa') }.to raise_error(ParseError, /too short/)
-          end
+        it 'sets header from a string' do
+          str = (1..icmp.sz).to_a.pack('C*') + 'body'
+          icmp.read str
+          expect(icmp.type).to eq(1)
+          expect(icmp.code).to eq(2)
+          expect(icmp.checksum).to eq(0x0304)
+          expect(icmp.body).to eq('body')
         end
 
-        describe '#calc_checksum' do
-          it 'computes ICMP header checksum' do
-            icmp = ICMP.new(type: 1, code: 8, body: (0..15).to_a.pack('C*'))
-            icmp.calc_checksum
-            expect(icmp.calc_checksum).to eq(0xc6b7)
-          end
+        it 'raises when str is too short' do
+          expect { icmp.read 'aa' }.to raise_error(ParseError, /too short/)
+          expect { icmp.read('aaa') }.to raise_error(ParseError, /too short/)
+        end
+      end
+
+      describe '#calc_checksum' do
+        it 'computes ICMP header checksum' do
+          icmp = ICMP.new(type: 1, code: 8, body: (0..15).to_a.pack('C*'))
+          icmp.calc_checksum
+          expect(icmp.calc_checksum).to eq(0xc6b7)
+        end
+      end
+
+      describe 'setters' do
+        let(:icmp) { ICMP.new}
+
+        it '#type= accepts integers' do
+          icmp.type = 0xef
+          expect(icmp[:type].to_i).to eq(0xef)
         end
 
-        describe 'setters' do
-          let(:icmp) { ICMP.new}
-
-          it '#type= accepts integers' do
-            icmp.type = 0xef
-            expect(icmp[:type].to_i).to eq(0xef)
-          end
-
-          it '#code= accepts integers' do
-            icmp.code = 0xea
-            expect(icmp[:code].to_i).to eq(0xea)
-          end
-
-          it '#checksum= accepts integers' do
-            icmp.checksum = 0xffff
-            expect(icmp[:checksum].to_i).to eq(65535)
-          end
+        it '#code= accepts integers' do
+          icmp.code = 0xea
+          expect(icmp[:code].to_i).to eq(0xea)
         end
 
-        describe '#to_s' do
-          it 'returns a binary string' do
-            icmp = ICMP.new(type: 1, code: 8, body: (0..15).to_a.pack('C*'))
-            icmp.calc_checksum
-            expect(icmp.to_s).to eq(([1, 8, 0xc6, 0xb7] + (0..15).to_a).pack('C*'))
+        it '#checksum= accepts integers' do
+          icmp.checksum = 0xffff
+          expect(icmp[:checksum].to_i).to eq(65535)
+        end
+      end
+
+      describe '#to_s' do
+        it 'returns a binary string' do
+          icmp = ICMP.new(type: 1, code: 8, body: (0..15).to_a.pack('C*'))
+          icmp.calc_checksum
+          expect(icmp.to_s).to eq(([1, 8, 0xc6, 0xb7] + (0..15).to_a).pack('C*'))
+        end
+      end
+      
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          icmp = ICMP.new
+          str = icmp.inspect
+          expect(str).to be_a(String)
+          (icmp.members - %i(body)).each do |attr|
+            expect(str).to include(attr.to_s)
           end
         end
       end

--- a/spec/header/icmpv6_spec.rb
+++ b/spec/header/icmpv6_spec.rb
@@ -91,6 +91,17 @@ module PacketGen
             expect(icmp.to_s).to eq(str)
         end
       end
+      
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          icmpv6 = ICMPv6.new
+          str = icmpv6.inspect
+          expect(str).to be_a(String)
+          (icmpv6.members - %i(body)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/header/ip_spec.rb
+++ b/spec/header/ip_spec.rb
@@ -199,6 +199,17 @@ module PacketGen
         end
       end
 
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          ip = IP.new
+          str = ip.inspect
+          expect(str).to be_a(String)
+          (ip.members - %i(body) + %i(version ihl flags frag_offset)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
+      end
+
       context 'frag field' do
         let(:ip) { IP.new }
 
@@ -234,7 +245,6 @@ module PacketGen
           ip.flag_rsv = true
           expect(ip.frag).to eq(0x9001)
         end
-
       end
     end
   end

--- a/spec/header/ip_spec.rb
+++ b/spec/header/ip_spec.rb
@@ -5,7 +5,7 @@ module PacketGen
 
     describe IP::Addr do
       before(:each) do
-        @ipaddr = IP::Addr.new.parse('192.168.25.43')
+        @ipaddr = IP::Addr.new.from_human('192.168.25.43')
       end
 
       it '#parse a string containing a dotted address' do
@@ -19,8 +19,8 @@ module PacketGen
         expect(@ipaddr.to_i).to eq(0xc0a8192b)
       end
 
-      it '#to_x returns a dotted address as String' do
-        expect(@ipaddr.to_x).to eq('192.168.25.43')
+      it '#to_human returns a dotted address as String' do
+        expect(@ipaddr.to_human).to eq('192.168.25.43')
       end
     end
 

--- a/spec/header/ipv6_spec.rb
+++ b/spec/header/ipv6_spec.rb
@@ -5,7 +5,7 @@ module PacketGen
 
     describe IPv6::Addr do
       before(:each) do
-        @ipv6addr = IPv6::Addr.new.parse('fe80::21a:c5ff:fe00:152')
+        @ipv6addr = IPv6::Addr.new.from_human('fe80::21a:c5ff:fe00:152')
       end
 
       it '#parse a string containing a dotted address' do
@@ -19,14 +19,14 @@ module PacketGen
         expect(@ipv6addr.a8).to eq(0x0152)
       end
 
-      it '#to_x returns a dotted address as String' do
-        expect(@ipv6addr.to_x).to eq('fe80::21a:c5ff:fe00:152')
+      it '#to_human returns a dotted address as String' do
+        expect(@ipv6addr.to_human).to eq('fe80::21a:c5ff:fe00:152')
       end
 
       it '#read gets a IPv6 address from a binary string' do
         bin_str = "\xfe\x80" << "\x00" * 6 << "\x02\x1a\xc5\xff\xfe\x00\x01\x52"
         ipv6addr = IPv6::Addr.new.read(bin_str)
-        expect(ipv6addr.to_x).to eq('fe80::21a:c5ff:fe00:152')
+        expect(ipv6addr.to_human).to eq('fe80::21a:c5ff:fe00:152')
       end
     end
 

--- a/spec/header/tcp_options_spec.rb
+++ b/spec/header/tcp_options_spec.rb
@@ -113,6 +113,19 @@ module PacketGen
             end
           end
         end
+
+        describe '#to_human' do
+          it 'returns a human-readable string' do
+            expected = ['MSS:1420, SACKOK, TS:36978029;0, NOP, WS:7',
+                        'MSS:1410, SACKOK, TS:2583455884;36978029, NOP, WS:7',
+                        'NOP, NOP, TS:36978033;2583455884']
+            @packets.each_with_index do |pkt, i|
+              str_opts = pkt[0x4a..-1]
+              opts.read str_opts
+              expect(opts.to_human).to eq(expected[i])
+            end
+          end
+        end
       end
     end
   end

--- a/spec/header/tcp_spec.rb
+++ b/spec/header/tcp_spec.rb
@@ -162,7 +162,7 @@ module PacketGen
 
         it 'may be accessed through all flag_* methods' do
           all_flags = (%i(flag_ns flag_cwr flag_ece flag_urg flag_ack flag_psh) +
-                       %i(flag_rst flas_syn flag_fin)).reverse
+                       %i(flag_rst flag_syn flag_fin)).reverse
           8.downto(0) do |i|
             expect(tcp.send "#{all_flags[i]}?").to eq(false)
             tcp.flags = 1 << i

--- a/spec/header/tcp_spec.rb
+++ b/spec/header/tcp_spec.rb
@@ -156,6 +156,17 @@ module PacketGen
           end
         end
       end
+      
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          tcp = TCP.new
+          str = tcp.inspect
+          expect(str).to be_a(String)
+          (tcp.members - %i(body) + %i(data_offset reserved flags)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
+      end
 
       context 'flags field' do
         let(:tcp) { TCP.new }

--- a/spec/header/udp_spec.rb
+++ b/spec/header/udp_spec.rb
@@ -103,11 +103,24 @@ module PacketGen
         end
       end
 
-      it '#to_s returns a binary string' do
-        udp = UDP.new(body: [0, 1, 2, 3].pack('C*'))
-        udp.calc_length
-        expected_str = "\x00" * 4 + "\x00\x0c\x00\x00\x00\x01\x02\x03"
-        expect(udp.to_s).to eq(PacketGen.force_binary expected_str)
+      describe '#to_s' do
+        it 'returns a binary string' do
+          udp = UDP.new(body: [0, 1, 2, 3].pack('C*'))
+          udp.calc_length
+          expected_str = "\x00" * 4 + "\x00\x0c\x00\x00\x00\x01\x02\x03"
+          expect(udp.to_s).to eq(PacketGen.force_binary expected_str)
+        end
+      end
+      
+      describe '#inspect' do
+        it 'returns a String with all attributes' do
+          udp = UDP.new
+          str = udp.inspect
+          expect(str).to be_a(String)
+          (udp.members - %i(body)).each do |attr|
+            expect(str).to include(attr.to_s)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR modifies Packet#inspect to remove logic from it.

Some methods moved to new Inspect module.
Packet#inspect now calls headers #inspect method (primarily defined in Header::HeaderMethods).