### PR TITLE
Add encapsulation/decapsulation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,10 @@ pkt.is? 'TCP'   # => true
 pkt.is? 'IP'    # => true
 pkt.is? 'UDP'   # => false
 
-# encapulsate/decapsulate packets (TODO)
-pkt2 = PacketGen.gen('IP').add('ESP', spi: 1234)
-pkt.encap pkt2                         # pkt is now a IP/ESP/IP/TCP packet
-                                       # eq. to pkt.encap('IP', 'ESP', esp_spi: 1234)
-pkt.decap('IP', 'ESP')                 # pkt is now inner IP/TCP packet
+# encapulsate/decapsulate packets
+pkt2 = PacketGen.gen('IP')
+pkt2.encapsulate pkt                   # pkt2 is now a IP/IP/TCP packet
+pkt2.decapsulate(pkt2.ip)              # pkt2 is now inner IP/TCP packet
 ```
 
 ### Read/write PcapNG files

--- a/lib/packetgen/packet.rb
+++ b/lib/packetgen/packet.rb
@@ -163,25 +163,7 @@ module PacketGen
       klass = check_protocol(protocol)
 
       header = klass.new(options)
-      prev_header = @headers.last
-      if prev_header
-        binding = prev_header.class.known_headers[klass]
-        if binding.nil?
-          msg = "#{prev_header.class} knowns no layer association with #{protocol}. "
-          msg << "Try #{prev_header.class}.bind_layer(PacketGen::Header::#{protocol}, "
-          msg << "#{prev_header.protocol_name.downcase}_proto_field: "
-          msg << "value_for_#{protocol.downcase})"
-          raise ArgumentError, msg
-        end
-        prev_header[binding.key].read binding.value
-        prev_header.body = header
-      end
-      header.packet = self
-      @headers << header
-      unless respond_to? protocol.downcase
-        self.class.class_eval "def #{protocol.downcase}(arg=nil);" \
-                              "header('#{protocol}', arg); end"
-      end
+      add_header header
       self
     end
 
@@ -257,6 +239,13 @@ module PacketGen
       end
     end
 
+    # Encapulate another packet in +self+
+    # @param [Packet] other
+    # @return [self] +self+ with new headers from +other+
+    def encapsulate(other)
+      other.headers.each { |h| add_header h }
+    end
+
     # @return [String]
     def inspect
       str = Inspect.dashed_line(self.class)
@@ -311,6 +300,32 @@ module PacketGen
       klass = Header.const_get(protocol)
       raise ArgumentError, "unknown #{protocol} protocol" unless klass.is_a? Class
       klass
+    end
+
+    # Add a header to packet
+    # @param [Header::HeaderMethods] header
+    # @return [void]
+    def add_header(header)
+      protocol = header.protocol_name
+      prev_header = @headers.last
+      if prev_header
+        binding = prev_header.class.known_headers[header.class]
+        if binding.nil?
+          msg = "#{prev_header.class} knowns no layer association with #{protocol}. "
+          msg << "Try #{prev_header.class}.bind_layer(PacketGen::Header::#{protocol}, "
+          msg << "#{prev_header.protocol_name.downcase}_proto_field: "
+          msg << "value_for_#{protocol.downcase})"
+          raise ArgumentError, msg
+        end
+        prev_header[binding.key].read binding.value
+        prev_header.body = header
+      end
+      header.packet = self
+      @headers << header
+      unless respond_to? protocol.downcase
+        self.class.class_eval "def #{protocol.downcase}(arg=nil);" \
+                              "header('#{protocol}', arg); end"
+      end
     end
   end
 end

--- a/spec/header_spec.rb
+++ b/spec/header_spec.rb
@@ -3,7 +3,8 @@ module PacketGen
   describe Header do
     it '.all returns all header classes' do
       expect(Header.all).to eq([Header::Eth, Header::IP, Header::ICMP, Header::ARP,
-                                Header::IPv6, Header::ICMPv6, Header::UDP, Header::TCP])
+                                Header::IPv6, Header::ICMPv6, Header::UDP, Header::TCP,
+                                Header::FakeHeader])
     end
   end
 end

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -201,28 +201,6 @@ module PacketGen
       end
     end
 
-    describe '.capture', :sudo  do
-      it 'captures packets using options' do
-        before = Time.now
-        Packet.capture('lo')
-        after = Time.now
-        expect(after - before).to be < 2
-      end
-
-      it 'yields captures packets' do
-        yielded_packets = []
-        packets = nil
-        cap_thread = Thread.new do
-          packets = Packet.capture('lo') { |pkt| yielded_packets << pkt }
-        end
-        sleep 0.1
-        system 'ping -c 2 127.0.0.1 > /dev/null'
-        cap_thread.join(0.5)
-        expect(yielded_packets.size).to eq(packets.size)
-        expect(yielded_packets).to eq(packets)
-      end
-    end
-
     describe '#add' do
       before(:each) do
         @pkt = Packet.gen('IP')

--- a/spec/packet_spec.rb
+++ b/spec/packet_spec.rb
@@ -152,6 +152,28 @@ module PacketGen
       end
     end
 
+    describe '.capture', :sudo  do
+      it 'captures packets using options' do
+        before = Time.now
+        Packet.capture('lo')
+        after = Time.now
+        expect(after - before).to be < 2
+      end
+
+      it 'yields captures packets' do
+        yielded_packets = []
+        packets = nil
+        cap_thread = Thread.new do
+          packets = Packet.capture('lo') { |pkt| yielded_packets << pkt }
+        end
+        sleep 0.1
+        system 'ping -c 2 127.0.0.1 > /dev/null'
+        cap_thread.join(0.5)
+        expect(yielded_packets.size).to eq(packets.size)
+        expect(yielded_packets).to eq(packets)
+      end
+    end
+
     describe '#add' do
       before(:each) do
         @pkt = Packet.gen('IP')


### PR DESCRIPTION
Add `Packet#encapsulate`:
```ruby
pkt1 = PacketGen.gen('Eth').add('IP')
pkt2 = PacketGen.gen('IP').add('ICMP')
pkt1.encapsulate pkt2  # => pkt1 is now a Eth/IP/IP/ICMP packet
```

Add `Packet#decapsulate` to remove some headers from a packet:
```ruby
pkt = PacketGen.gen('IP').add('IP').add('ICMP')   # => IP/IP/ICMP packet
pkt.decapsulate pkt.ip                            # => IP/ICMP packet (first IP header removed)
```