### PR TITLE
update config initialization to be compatible on macOS

### DIFF
--- a/bin/pgconsole
+++ b/bin/pgconsole
@@ -1,5 +1,3 @@
-# Path setting slight of hand you can ignore if not running it for debugging, basically
-# $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 #!/usr/bin/env ruby
 
 require 'bundler/setup'

--- a/bin/pgconsole
+++ b/bin/pgconsole
@@ -1,3 +1,5 @@
+# Path setting slight of hand you can ignore if not running it for debugging, basically
+# $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 #!/usr/bin/env ruby
 
 require 'bundler/setup'

--- a/lib/packetgen/config.rb
+++ b/lib/packetgen/config.rb
@@ -5,6 +5,7 @@ module PacketGen
 
   # Config class to provide +config+ object to pgconsole
   # @author Sylvain Daubert
+  # @author Kent 'picat' Gruber 
   class Config
 
     # Default network interface
@@ -20,12 +21,12 @@ module PacketGen
     # @return [String] 
     attr_reader :ip6addr
 
-    # Create a configuration object. If +iface+ is not set, get first network interface.
-    # If non exists, use loopback one.
+    # Create a configuration object. If +iface+ is not set then 
+    # it will be attempted to be found automatically. 
     # @param [String,nil] iface
     def initialize(iface=nil)
       if iface.nil?
-        iface = NetworkInterface.interfaces.select { |iface| iface != 'lo' }.first
+        iface = Pcap.lookupdev
         iface = NetworkInterface.interfaces.first if iface.nil?
       end
       @iface = iface

--- a/lib/packetgen/config.rb
+++ b/lib/packetgen/config.rb
@@ -21,13 +21,17 @@ module PacketGen
     # @return [String] 
     attr_reader :ip6addr
 
-    # Create a configuration object. If +iface+ is not set then 
-    # it will be attempted to be found automatically. 
+    # Create a configuration object. If +iface+ is not set,
+    # attempt to find it automatically or default to the 
+    # first available loopback interface.
     # @param [String,nil] iface
     def initialize(iface=nil)
       if iface.nil?
-        iface = Pcap.lookupdev
-        iface = NetworkInterface.interfaces.first if iface.nil?
+        begin
+          iface = Pcap.lookupdev
+        rescue PCAPRUB::BindingError
+          iface = NetworkInterface.interfaces.select { |iface| iface =~ /lo/ }.first
+        end
       end
       @iface = iface
 


### PR DESCRIPTION
The mac address determining seems to work fine for me. I wonder what
windows has for for its socket interface… is the check maybe a little
too strict not allowing for happy happenstances? I dunno. Works.

I also decided that the Network interface loop to determine the default
wasn’t all that magical for me. In fact, for my case, since my loopback
interface was lo0 — it would actually just fail for me.

Pcaprub has a nice lookupdev method which I think works great for
determining a working interface, so I just used that. Did a little
documentation cleanup to reflect that. Feel free to modify.