### PR TITLE
Read pcap formatted files

### DIFF
--- a/lib/packetgen/packet.rb
+++ b/lib/packetgen/packet.rb
@@ -91,11 +91,21 @@ module PacketGen
 
     # Read packets from +filename+.
     #
-    # For more control, see {PcapNG::File}.
-    # @param [String] filename PcapNG file
+    # For more control, see {PcapNG::File} or {PCAPRUB::Pcap}.
+    # @param [String] filename PcapNG or Pcap file.
     # @return [Array<Packet>]
     def self.read(filename)
-      PcapNG::File.new.read_packets filename
+      begin
+        PcapNG::File.new.read_packets filename
+      rescue => e
+        raise ArgumentError, e unless File.extname(filename.downcase) == '.pcap'
+        packets = []
+        PCAPRUB::Pcap.open_offline(filename).each_packet do |packet|
+          next unless packet = PacketGen.parse(packet.to_s)  
+          packets << packet
+        end
+        packets
+      end
     end
 
     # Write packets to +filename+


### PR DESCRIPTION
This seems to work for me and handles the error packetgen has currently:

```ruby
PacketGen::PcapNG::InvalidFileError: Incoherency in Header Block
from /.../lib/packetgen/pcapng/unknown_block.rb:58:in `read'
```

And returns an array of parsed packets when given a `.pcap` file. 🙌 

## Side Thought
Perhaps some defensiveness could be baked into handle packets that cannot be parsed upon reading a little more wisely. Perhaps that could be tinkered with a bit more. At least from reading the `.pcap` formatted files. I haven't read how `PcapNG` deals with packets that it cannot parse when reading from a file. 

Would love to know you thoughts on that. ⛵️ 

### Lol
Otherwise, finally made that PR. 😊 