### PR TITLE
fix typo

### DIFF
--- a/lib/packetgen/header/tcp/options.rb
+++ b/lib/packetgen/header/tcp/options.rb
@@ -48,7 +48,7 @@ module PacketGen
 
         def real_type(opt)
           klasses = self.class.option_classes
-          klasses[opt.kind].nil? ? OPtion : klasses[opt.kind]
+          klasses[opt.kind].nil? ? Option : klasses[opt.kind]
         end
       end
     end


### PR DESCRIPTION
I stumbled across a 🐛 bug while trying to re-create [this](https://twitter.com/ihackbanme/status/1057811965945376768).

# Steps to Reproduce Error
```ruby
require "packetgen"

PacketGen.parse("G\x00\x00X\x00\x01\x00\x00@\x06Y{\n\x00\x00\x10\x08\x08\x08\x08AAAAAAAA\x00\x14\t\x13\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x02\x00'\xcd\x00\x00\x13\x14111111111111111111\x13\x14222222222222222222")
```
```
NameError: uninitialized constant PacketGen::Header::TCP::Options::OPtion
Did you mean?  PacketGen::Header::TCP::Option
               PacketGen::Header::TCP::Options
from .../gems/packetgen-3.0.1/lib/packetgen/header/tcp/options.rb:51:in `real_type'
```

# Fix
The fix is simple: `OPtion` -> `Option`

🙇 Thank you again for all your work @sdaubert!