### PR TITLE
Add monitor (rfmon) support.

### DIFF
--- a/lib/packetgen/capture.rb
+++ b/lib/packetgen/capture.rb
@@ -13,7 +13,7 @@ module PacketGen
   class Capture
     private
 
-    attr_reader :filter, :cap_thread, :snaplen, :promisc
+    attr_reader :filter, :cap_thread, :snaplen, :promisc, :monitor
 
     public
 
@@ -41,14 +41,15 @@ module PacketGen
     #    yielding.  Default: +true+
     # @param [Integer] snaplen maximum number of bytes to capture for
     #    each packet.
+    # @param [Boolean] monitor enable or disable monitor mode on interface (if supported).
     # @since 2.0.0 remove old 1.x API
     # @since 3.0.0 arguments are kwargs and no more a hash
-    def initialize(iface: nil, max: nil, timeout: nil, filter: nil, promisc: false, parse: true, snaplen: nil)
+    def initialize(iface: nil, max: nil, timeout: nil, filter: nil, promisc: false, parse: true, snaplen: nil, monitor: nil)
       @iface = iface || PacketGen.default_iface || PacketGen.loopback_iface
 
       @packets     = []
       @raw_packets = []
-      set_options iface, max, timeout, filter, promisc, parse, snaplen
+      set_options iface, max, timeout, filter, promisc, parse, snaplen, monitor
     end
 
     # Start capture
@@ -56,8 +57,8 @@ module PacketGen
     # @yieldparam [Packet,String] packet if a block is given, yield each
     #    captured packet (Packet or raw data String, depending on +:parse+ option)
     # @since 3.0.0 arguments are kwargs and no more a hash
-    def start(iface: nil, max: nil, timeout: nil, filter: nil, promisc: false, parse: true, snaplen: nil, &block)
-      set_options iface, max, timeout, filter, promisc, parse, snaplen
+    def start(iface: nil, max: nil, timeout: nil, filter: nil, promisc: false, parse: true, snaplen: nil, monitor: nil, &block)
+      set_options iface, max, timeout, filter, promisc, parse, snaplen, monitor
 
       @cap_thread = Thread.new do
         PCAPRUBWrapper.capture(**capture_args) do |packet_data|
@@ -79,7 +80,7 @@ module PacketGen
 
     private
 
-    def set_options(iface, max, timeout, filter, promisc, parse, snaplen)
+    def set_options(iface, max, timeout, filter, promisc, parse, snaplen, monitor)
       @max = max if max
       @filter = filter unless filter.nil?
       @timeout = timeout unless timeout.nil?
@@ -87,10 +88,11 @@ module PacketGen
       @snaplen = snaplen unless snaplen.nil?
       @parse = parse unless parse.nil?
       @iface = iface unless iface.nil?
+      @monitor = monitor unless monitor.nil?
     end
 
     def capture_args
-      h = { iface: iface, filter: filter }
+      h = { iface: iface, filter: filter, monitor: monitor }
       h[:snaplen] = snaplen unless snaplen.nil?
       h[:promisc] = promisc unless promisc.nil?
       h

--- a/lib/packetgen/pcaprub_wrapper.rb
+++ b/lib/packetgen/pcaprub_wrapper.rb
@@ -23,9 +23,16 @@ module PacketGen
     # @param [String] iface interface name
     # @param [Integer] snaplen
     # @param [Boolean] promisc
+    # @param [Boolean] monitor
     # @return [PCAPRUB::Pcap]
-    def self.open_iface(iface:, snaplen: DEFAULT_SNAPLEN, promisc: DEFAULT_PROMISC)
-      PCAPRUB::Pcap.open_live(iface, snaplen, promisc, TIMEOUT)
+    def self.open_iface(iface:, snaplen: DEFAULT_SNAPLEN, promisc: DEFAULT_PROMISC, monitor: nil)
+      pcap = PCAPRUB::Pcap.create(iface)
+      pcap.setsnaplen(snaplen)
+      pcap.setpromisc(promisc)
+      pcap.settimeout(TIMEOUT)
+      # Monitor MUST be set before pcap is activated
+      pcap.setmonitor monitor unless monitor.nil?
+      pcap.activate
     end
 
     # Capture packets from a network interface
@@ -33,10 +40,11 @@ module PacketGen
     # @param [Integer] snaplen
     # @param [Boolean] promisc
     # @param [String] filter BPF filter
+    # @param [Boolean] monitor
     # @yieldparam [String] packet_data binary packet data
     # @return [void]
-    def self.capture(iface:, snaplen: DEFAULT_SNAPLEN, promisc: DEFAULT_PROMISC, filter: nil)
-      pcap = self.open_iface(iface: iface, snaplen: snaplen, promisc: promisc)
+    def self.capture(iface:, snaplen: DEFAULT_SNAPLEN, promisc: DEFAULT_PROMISC, filter: nil, monitor: nil)
+      pcap = self.open_iface(iface: iface, snaplen: snaplen, promisc: promisc, monitor: monitor)
       pcap.setfilter filter unless filter.nil?
       pcap.each do |packet_data|
         yield packet_data

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -13,7 +13,7 @@ module PacketGen
       end
 
       it 'accepts options' do
-        options = { max: 12, timeout: 30, filter: 'ip', promisc: true, snaplen: 45 }
+        options = { max: 12, timeout: 30, filter: 'ip', promisc: true, snaplen: 45, monitor: true }
         expect { Capture.new(options) }.to_not raise_error
       end
     end


### PR DESCRIPTION
Add monitor support using [`pcap_set_rfmon()`](https://man.openbsd.org/pcap_set_rfmon.3#pcap_set_rfmon).

Makes it easier to put the interface in monitor mode without needing to shell out to another tool. Obviously only works with NICs that support entering monitor mode using libpcap.

Tested on macOS 10.15.3 (19D76).

Let me know if you want any changes since it digs pretty deep into your abstractions.

Also probably needs a wiki update for the [wifi example](https://github.com/sdaubert/packetgen/wiki/WiFi#capturing-wifi-packets).