### PR TITLE
Fix NoMethodError in deprecation warning

### DIFF
--- a/lib/packetgen/deprecation.rb
+++ b/lib/packetgen/deprecation.rb
@@ -31,7 +31,7 @@ module PacketGen
       complete_deprecated_method_name = "#{base_name}#{deprecated_method}"
       complete_new_method_name = "#{base_name}#{new_method}" unless new_method.nil?
 
-      file, line = caller(2..2).split(':')[0, 2]
+      file, line = caller(2..2).first.split(':')[0, 2]
       message = +"#{file}:#{line}: #{complete_deprecated_method_name} is deprecated"
       message << " in favor of #{complete_new_method_name}" unless new_method.nil?
       message << '. ' << self.removed(remove_version)


### PR DESCRIPTION
Fixes
```
packetgen/lib/packetgen/deprecation.rb:35:in `deprecated': undefined method `split' for ["script.rb:19:in `<main>'"]:Array (NoMethodError)
```
when using a deprecated method.