### PR TITLE
Add timestamps on capture

### DIFF
--- a/lib/packetgen.rb
+++ b/lib/packetgen.rb
@@ -64,8 +64,10 @@ module PacketGen
   # Shortcut for {Packet.capture}
   # Same arguments as {Capture#initialize}
   # @see Capture#initialize
-  # @yieldparam [Packet] packet
+  # @yieldparam [Packet,String] packet
+  # @yieldparam [Time] timestamp
   # @return [Array<Packet>]
+  # @since 3.3.0 add packet timestamp as second yield parameter
   def self.capture(**kwargs)
     Packet.capture(**kwargs) { |packet| yield packet if block_given? }
   end

--- a/lib/packetgen/packet.rb
+++ b/lib/packetgen/packet.rb
@@ -81,7 +81,9 @@ module PacketGen
     # @see Capture#initialize
     # @yieldparam [Packet,String] packet if a block is given, yield each
     #    captured packet (Packet or raw data String, depending on +:parse+ option)
+    # @yieldparam [Time] timestamp packet timestamp
     # @return [Array<Packet>] captured packet
+    # @since 3.3.0 add packet timestamp as second yield parameter
     def self.capture(**kwargs, &block)
       capture = Capture.new(**kwargs)
       if block

--- a/lib/packetgen/pcaprub_wrapper.rb
+++ b/lib/packetgen/pcaprub_wrapper.rb
@@ -44,7 +44,7 @@ module PacketGen
     # @param [Boolean] promisc
     # @param [String] filter BPF filter
     # @param [Boolean] monitor
-    # @yieldparam [String] packet_data binary packet data
+    # @yieldparam [String] packet_data packet data
     # @return [void]
     # @author Sylvain Daubert
     # @author optix2000 - add support for setting monitor mode
@@ -52,7 +52,7 @@ module PacketGen
     def self.capture(iface:, snaplen: DEFAULT_SNAPLEN, promisc: DEFAULT_PROMISC, filter: nil, monitor: nil, &block)
       pcap = self.open_iface(iface: iface, snaplen: snaplen, promisc: promisc, monitor: monitor)
       pcap.setfilter filter unless filter.nil?
-      pcap.each(&block)
+      pcap.each_packet(&block)
     end
 
     # Inject given data onto wire

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 module PacketGen
@@ -106,6 +108,22 @@ module PacketGen
         expect(yielded_packets.size).to eq(cap.raw_packets.size)
         expect(yielded_packets).to eq(cap.raw_packets)
       end
+
+      it 'yields packet timestamp' do
+        timestamps = []
+        cap = Capture.new(iface: 'lo', parse: false, timeout: 3)
+        cap_thread = Thread.new { cap.start { |_pkt, ts| timestamps << ts } }
+        sleep 0.1
+        ping('127.0.0.1', count: 1)
+        cap_thread.join(0.5)
+        expect(cap.packets.size).to be >= 2
+        expect(timestamps.size).to eq(cap.packets.size)
+        timestamps.each do |ts|
+          expect(ts).to be_a(Time)
+        end
+      end
+
+      it 'yields raw packet timestamp'
     end
   end
 end

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -111,7 +111,7 @@ module PacketGen
 
       it 'yields packet timestamp' do
         timestamps = []
-        cap = Capture.new(iface: 'lo', parse: false, timeout: 3)
+        cap = Capture.new(iface: 'lo', timeout: 3)
         cap_thread = Thread.new { cap.start { |_pkt, ts| timestamps << ts } }
         sleep 0.1
         ping('127.0.0.1', count: 1)
@@ -123,7 +123,19 @@ module PacketGen
         end
       end
 
-      it 'yields raw packet timestamp'
+      it 'yields raw packet timestamp' do
+        timestamps = []
+        cap = Capture.new(iface: 'lo', parse: false, timeout: 3)
+        cap_thread = Thread.new { cap.start { |_pkt, ts| timestamps << ts } }
+        sleep 0.1
+        ping('127.0.0.1', count: 1)
+        cap_thread.join(0.5)
+        expect(cap.raw_packets.size).to be >= 2
+        expect(timestamps.size).to eq(cap.raw_packets.size)
+        timestamps.each do |ts|
+          expect(ts).to be_a(Time)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`Capture#start` now records packets timestamps in `Capture#timestamps` and yield them as a second block argument.